### PR TITLE
Fixing Set wifi white screen when opening Chromium

### DIFF
--- a/kano_settings/set_wifi/wifi.py
+++ b/kano_settings/set_wifi/wifi.py
@@ -137,7 +137,7 @@ def activate(_win, _box, _button, _proxy_button, _disable_proxy=None):
 
 def launch_chromium(widget=None, event=None):
     user_name = get_user_unsudoed()
-    os.system('su ' + user_name + ' -c chromium')
+    utils.run_bg('su - ' + user_name + ' -c chromium')
 
 
 def network_info():


### PR DESCRIPTION
- Starts Chromium in the background, so the settings screen can process user events
- Adding a dash to su so that user environment is populated to Chromium
