### PR TITLE
Fixing possibility to set parental lock with empty password

### DIFF
--- a/kano_settings/set_advanced.py
+++ b/kano_settings/set_advanced.py
@@ -246,7 +246,11 @@ class SetPassword(Template):
         else:
             self.entry1.set_sensitive(True)
             self.entry2.set_sensitive(True)
-            button.set_sensitive(True)
+
+            # For new password input dialog (2 entry fields) the lock button
+            # will be enabled only after the user enters text
+            # in both password fields (self.enable_button)
+            button.set_sensitive(False)
 
     def create_dialog(self, message1, message2):
         kdialog = KanoDialog(


### PR DESCRIPTION
- After failing to provide a valid new password, the retry dialog
  now forcibly disables the lock button, which will effectively
  be re-enabled once the user enters data in both password fields.
