### PR TITLE
Kano init reset audio fix

### DIFF
--- a/kano_settings/boot_config.py
+++ b/kano_settings/boot_config.py
@@ -34,7 +34,7 @@ def set_config_value(name, value=None):
                 if value is not None:
                     replace_str = str(name) + "=" + str(value)
                 else:
-                    replace_str = r'#' + str(name) + r'=\1'
+                    replace_str = r'#' + str(name) + r'=0'
                 new_line = replace_str
             else:
                 new_line = line

--- a/kano_settings/set_audio.py
+++ b/kano_settings/set_audio.py
@@ -91,12 +91,6 @@ class SetAudio(Template):
                 set_config_value("hdmi_drive", None)
                 config = "Analogue"
 
-            # if audio settings haven't changed, don't apply new changes
-            if get_setting('Audio') == config:
-                logger.debug("set_audio / apply_changes: audio settings haven't changed, don't apply new changes")
-                self.win.go_to_home()
-                return
-
             file_replace(self.rc_local_path, amixer_from, amixer_to)
             set_setting('Audio', config)
 

--- a/kano_settings/set_overclock.py
+++ b/kano_settings/set_overclock.py
@@ -74,31 +74,31 @@ class SetOverclock(RadioButtonTemplate):
             # None configuration
             if self.selected_button == 0:
                 config = "None"
-                arm_freq = "700"
-                core_freq = "250"
-                sdram_freq = "400"
-                over_voltage = "0"
+                arm_freq = 700
+                core_freq = 250
+                sdram_freq = 400
+                over_voltage = 0
             # Modest configuration
             elif self.selected_button == 1:
                 config = "Modest"
-                arm_freq = "800"
-                core_freq = "300"
-                sdram_freq = "400"
-                over_voltage = "0"
+                arm_freq = 800
+                core_freq = 300
+                sdram_freq = 400
+                over_voltage = 0
             # Medium configuration
             elif self.selected_button == 2:
                 config = "Medium"
-                arm_freq = "900"
-                core_freq = "333"
-                sdram_freq = "450"
-                over_voltage = "2"
+                arm_freq = 900
+                core_freq = 333
+                sdram_freq = 450
+                over_voltage = 2
             # High configuration
             elif self.selected_button == 3:
                 config = "High"
-                arm_freq = "950"
-                core_freq = "450"
-                sdram_freq = "450"
-                over_voltage = "6"
+                arm_freq = 950
+                core_freq = 450
+                sdram_freq = 450
+                over_voltage = 6
             else:
                 logger.error('kano-settings: set_overclock: SetOverclock: set_overclock(): ' +
                              'was called with an invalid self.selected_button={}'.format(self.selected_button))


### PR DESCRIPTION
- Replaced `file_replace` with `set_config_value` to fix incompatibility with `sudo kano-init reset`

https://github.com/KanoComputing/peldins/issues/1158
