### PR TITLE
Set default parental setting to high

### DIFF
--- a/kano_settings/config_file.py
+++ b/kano_settings/config_file.py
@@ -40,7 +40,7 @@ defaults = {
     'Mouse': 'Normal',
     'Font': 'Normal',
     'Wallpaper': 'kanux-background',
-    'Parental-level': 0
+    'Parental-level': 2
 }
 
 


### PR DESCRIPTION
The previous default setting for when the parental lock is enabled is
the lowest. Switch it to the highest.