### PR TITLE
Make the monitor edid parsing more resilient

### DIFF
--- a/kano_settings/system/display.py
+++ b/kano_settings/system/display.py
@@ -277,7 +277,7 @@ def parse_edid(edid_txt):
         elif 'no audio support' in l:
             edid['hdmi_audio'] = False
 
-    # setting target mdoe
+    # setting target mode
     if found:
         edid['target_group'] = edid['found_group']
         edid['target_mode'] = edid['found_mode']
@@ -288,8 +288,10 @@ def parse_edid(edid_txt):
     # is_monitor
     if edid['target_group'] == 'DMT':
         edid['is_monitor'] = True
+    elif 'TV' in edid['model']:
+        edid['is_monitor'] = False
     else:
-        edid['is_monitor'] = edid['dmt_found'] or edid['screen_size'] < 60
+        edid['is_monitor'] = edid['dmt_found'] or edid.get('screen_size') < 60
 
     # always disable overscan
     edid['target_overscan'] = False


### PR DESCRIPTION
KanoComputing/peldins#1531
The monitor edid parsing would fail if it is detected that the device is
CEA but the screen size detection fails. Adds a more resilient method to
compare the screen size. Also adds an extra check to detect if it is a
monitor or a television - if the model name includes 'TV' then it is a
good indication that the device is a television.