### PR TITLE
Switch to use resolvconf for setting DNS

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Build-Depends: debhelper (>= 9), build-essential, pkg-config, libgtk2.0-dev,
 Package: kano-settings
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, python, python-gi, dante-client,
-         kano-toolset (>= 1.3-5), kano-profile, gir1.2-gtk-3.0, libkdesk-dev
+         kano-toolset (>= 1.3-6), kano-profile, gir1.2-gtk-3.0, libkdesk-dev
 Recommends: kano-fonts
 Description: Graphical tool to set different system settings
  This application is a GUI frontend to set multiple Kano OS functionalities

--- a/kano_settings/system/advanced.py
+++ b/kano_settings/system/advanced.py
@@ -16,7 +16,8 @@ from kano.utils import read_file_contents, write_file_contents, \
     read_file_contents_as_lines, read_json, write_json, ensure_dir, \
     get_user_unsudoed
 from kano.logging import logger
-from kano.network import set_dns
+from kano.network import set_dns, restore_dns_interfaces, \
+    clear_dns_interfaces, refresh_resolvconf
 
 password_file = "/etc/kano-parental-lock"
 hosts_file = '/etc/hosts'
@@ -191,9 +192,13 @@ def set_dns_parental(enabled):
     if enabled:
         logger.debug('Enabling parental DNS servers (OpenDNS servers)')
         set_dns(open_dns_servers)
+        clear_dns_interfaces()
     else:
         logger.debug('Disabling parental DNS servers (Google servers)')
         set_dns(google_servers)
+        restore_dns_interfaces()
+
+    refresh_resolvconf()
 
 
 def read_listed_sites():


### PR DESCRIPTION
KanoComputing/peldins#1543
Currently, if the parental controls are enabled and the interface
obtains a new network configuration via DHCP, the parental DHCP servers
will be replaced by the DNS servers from DHCP. Resolvconf allows finer
control over which DNS servers are used, providing the ability to
prevent DNS servers configured by DHCP from being used.

This patch fixes the problem by changing the DNS settings through
resolvconf and disabling DHCP DNS servers when parental DNS is being
used.