### PR TITLE
use .format() instead of %

### DIFF
--- a/kano_settings/set_about.py
+++ b/kano_settings/set_about.py
@@ -38,14 +38,23 @@ class SetAbout(Gtk.Box):
 
         image = Gtk.Image.new_from_file(media + "/Graphics/about-screen.png")
 
-        version_align = self.create_version_align()
-        space_available = get_space_available()
-        temperature = get_temperature()
-        model_name = get_model_name()
-
-        space_align = self.create_other_align(space_available)
-        temperature_align = self.create_other_align(temperature)
-        model_align = self.create_other_align(model_name)
+        version_align = self.create_align(
+            "Kano OS v.{version}".format(version = get_current_version()),
+            'about_version'
+            )
+        space_align = self.create_align(
+            "Disk space used: {used}B / {total}B".format(**get_space_available())
+        )
+        try:
+            celsius = u"{:.1f}\N{DEGREE SIGN}C".format(get_temperature())
+        except ValueError:
+            celsius = "?"
+        temperature_align = self.create_align(
+            u"Temperature: {celsius}".format(celsius = celsius)
+        )
+        model_align = self.create_align(
+            "Model: {model}".format(model = get_model_name())
+        )
 
         terms_and_conditions = OrangeButton("Terms and conditions")
         terms_and_conditions.connect(
@@ -89,27 +98,12 @@ class SetAbout(Gtk.Box):
         # Refresh window
         self.win.show_all()
 
-    def create_version_align(self):
-        '''This is the widget (Gtk.Alignment) containing the version
-        information. This has different styling to the other information
-        '''
-
-        version_number = get_current_version()
-        version_long = "Kano OS v." + version_number
-        label = Gtk.Label(version_long)
-        label.get_style_context().add_class("about_version")
-
-        align = Gtk.Alignment(xalign=0.5, xscale=0, yalign=0, yscale=0)
-        align.add(label)
-
-        return align
-
-    def create_other_align(self, text):
-        '''This is the default template for any other information
+    def create_align(self, text, css_class='about_label'):
+        '''This styles the status information in the 'about' dialog
         '''
 
         label = Gtk.Label(text)
-        label.get_style_context().add_class("about_label")
+        label.get_style_context().add_class(css_class)
 
         align = Gtk.Alignment(xalign=0.5, xscale=0, yalign=0, yscale=0)
         align.add(label)

--- a/kano_settings/system/about.py
+++ b/kano_settings/system/about.py
@@ -12,40 +12,39 @@ from kano.utils import is_model_a, is_model_b, is_model_b_plus, is_model_2_b
 
 
 def get_current_version():
-    output = subprocess.check_output(["cat", "/etc/kanux_version"])
-    version_number = output.split("-")[-1].strip()
+    version_number = "?"
+    with open('/etc/kanux_version', 'r') as f:
+        output = f.read().strip()
+        version_number = output.split('-')[-1]
     return version_number
 
 
 def get_space_available():
     output = subprocess.check_output("df -h | grep rootfs", shell=True)
-    items = output.strip().split(" ")
+    items = output.strip().split(' ')
     items = filter(None, items)
-    total_space = items[1]
-    space_used = items[2]
-    return "Disk space used: " + space_used + "B / " + total_space + "B"
+    return {
+        'used': items[1],
+        'total': items[2]
+    }
 
 
 def get_temperature():
-    degree_sign = u'\N{DEGREE SIGN}'
-    output = subprocess.check_output("cputemp0=`cat /sys/class/thermal/thermal_zone0/temp`; \
-                                     cputemp1=$(($cputemp0/1000)); \
-                                     cputemp2=$(($cputemp0/100)); \
-                                     cputemp=$(($cputemp2%$cputemp1)); \
-                                     echo $cputemp1\".\"$cputemp", shell=True)
-    output = output.strip()
-    return "Temperature: " + output + degree_sign + "C"
+    temperature = None
+    with open('/sys/class/thermal/thermal_zone0/temp') as f:
+        output = f.read().strip()
+        temperature = int(output) / 1000.0
+    return temperature
 
 
 def get_model_name():
-    board_info = "Model: Raspberry Pi"
     if is_model_a():
-        board_info += " A"
+        model = "A"
     elif is_model_b():
-        board_info += " B"
+        model = "B"
     elif is_model_b_plus():
-        board_info += " B+"
+        model = "B+"
     elif is_model_2_b():
-        board_info += " 2"
+        model = "2"
 
-    return board_info
+    return "Raspberry Pi {}".format(model)

--- a/kano_settings/system/account.py
+++ b/kano_settings/system/account.py
@@ -20,7 +20,7 @@ def add_user():
 
 # Needs sudo permission
 def delete_user():
-    os.system('kano-init deleteuser %s' % (get_user_unsudoed()))
+    os.system('kano-init deleteuser {}'.format(get_user_unsudoed()))
     # back up profile
     if has_token():
         os.system("kano-sync --sync --backup")
@@ -44,5 +44,5 @@ def verify_current_password(password):
 
 # Successfully changed password is returns 0, else is successful
 def change_password(new_password):
-    out, e, cmdvalue = run_cmd("echo $SUDO_USER:%s | chpasswd" % (new_password))
+    out, e, cmdvalue = run_cmd("echo $SUDO_USER:{} | chpasswd".format(new_password))
     return cmdvalue

--- a/kano_settings/system/advanced.py
+++ b/kano_settings/system/advanced.py
@@ -122,7 +122,7 @@ def set_hosts_blacklist(enable, blacklist_file='/usr/share/kano-settings/media/P
             shutil.copyfile(hosts_file, hosts_file_backup)
 
             logger.debug('appending the blacklist`')
-            os.system('zcat %s >> %s' % (blacklist_file, hosts_file))
+            os.system('zcat {} >> {}'.format(blacklist_file, hosts_file))
 
             logger.debug('making the file root read-only')
             os.chmod(hosts_file, 0644)

--- a/kano_settings/system/display.py
+++ b/kano_settings/system/display.py
@@ -33,7 +33,7 @@ def switch_display_safe_mode():
          if resolution == safe_resolution:
             group=m.split()[0].split(':')[0]
             mode=m.split()[0].split(':')[1]
-            logger.info ('Switching display to safe resolution %s (group=%s mode=%s)' % (resolution, group, mode))
+            logger.info ('Switching display to safe resolution {} (group={} mode={})'.format(resolution, group, mode))
             set_hdmi_mode_live(group, mode)
    except:
       logger.error ('Error switching display to safe mode')
@@ -76,12 +76,12 @@ def list_supported_modes():
 
     for key in sorted(cea_modes):
         values = cea_modes[key]
-        string = "cea:%d  %s  %s  %s" % (key, values[0], values[1], values[2])
+        string = "cea:{:d}  {}  {}  {}".format(key, values[0], values[1], values[2])
         modes.append(string)
 
     for key in sorted(dmt_modes):
         values = dmt_modes[key]
-        string = "dmt:%d  %s  %s  %s" % (key, values[0], values[1], values[2])
+        string = "dmt:{:d}  {}  {}  {}".format(key, values[0], values[1], values[2])
         modes.append(string)
 
     return modes
@@ -93,12 +93,12 @@ def set_hdmi_mode_live(group=None, mode=None, drive='HDMI'):
         return success
 
     # ask tvservice to switch to the given mode immediately
-    status_str, _, rc = run_cmd(tvservice_path + ' -e "%s %s %s"' % (group, mode, drive))
+    status_str, _, rc = run_cmd(tvservice_path + ' -e "{} {} {}"'.format(group, mode, drive))
     if rc == 0 and os.path.exists(fbset_path) and os.path.exists(xrefresh_path):
         # refresh the Xserver screen because most probably it has become black as a result of the graphic mode switch.
         # we wait a tiny bit because on some occassions it happens to early and has no effect (leaves the screen black).
         time.sleep(2)
-        _, _, _ = run_cmd('%s -depth 8 ; %s -depth 16' % (fbset_path, fbset_path))
+        _, _, _ = run_cmd('{} -depth 8 ; {} -depth 16'.format(fbset_path, fbset_path))
         _, _, _ = run_cmd(xrefresh_path)
         success = True
 

--- a/kano_settings/system/proxy.py
+++ b/kano_settings/system/proxy.py
@@ -41,11 +41,11 @@ def set_chromium(enable, host=None, port=None):
     if enable:
         proxy_type = 'http'
 
-        strflags = '"--password-store=detect --proxy-server="%s:\/\/%s:%s""' % (proxy_type, host, port)
+        strflags = '"--password-store=detect --proxy-server="{}:\/\/{}:{}""'.format(proxy_type, host, port)
     else:
         strflags = '"--password-store=detect"'
 
-    cmd = "/bin/sed -i 's/CHROMIUM_FLAGS=.*/CHROMIUM_FLAGS=%s/g' %s" % (strflags, chromium_cfg)
+    cmd = "/bin/sed -i 's/CHROMIUM_FLAGS=.*/CHROMIUM_FLAGS={}/g' {}".format(strflags, chromium_cfg)
     run_cmd(cmd)
     return
 

--- a/kano_settings/system/wallpaper.py
+++ b/kano_settings/system/wallpaper.py
@@ -12,7 +12,7 @@
 from kano.logging import logger
 import os
 
-kdeskrc_home = "/home/%s/.kdeskrc"
+kdeskrc_home = "/home/{user}/.kdeskrc"
 
 
 def change_wallpaper(path, name):
@@ -20,12 +20,12 @@ def change_wallpaper(path, name):
 
     # home directory
     USER = os.environ['SUDO_USER']
-    deskrc_path = kdeskrc_home % (USER)
+    deskrc_path = kdeskrc_home.format(user = USER)
 
     # Wallpaper selected
-    image_169 = "%s%s-16-9.png" % (path, name)
-    image_43 = "%s%s-4-3.png" % (path, name)
-    image_1024 = "%s%s-1024.png" % (path, name)
+    image_169 = "{}{}-16-9.png".format(path, name)
+    image_43 = "{}{}-4-3.png".format(path, name)
+    image_1024 = "{}{}-1024.png".format(path, name)
 
     # Look for the strings
     found = False
@@ -34,12 +34,12 @@ def change_wallpaper(path, name):
         newlines = []
         for line in f:
             if "Background.File-medium:" in line:
-                line = "  Background.File-medium: %s\n" % (image_1024)
+                line = "  Background.File-medium: {}\n".format(image_1024)
                 found = True
             elif "Background.File-4-3:" in line:
-                line = "  Background.File-4-3: %s\n" % (image_43)
+                line = "  Background.File-4-3: {}\n".format(image_43)
             elif "Background.File-16-9:" in line:
-                line = "  Background.File-16-9: %s\n" % (image_169)
+                line = "  Background.File-16-9: {}\n".format(image_169)
             newlines.append(line)
         f.close()
     if found:
@@ -52,11 +52,11 @@ def change_wallpaper(path, name):
     # If not found add it
     else:
         with open(deskrc_path, "a") as outfile:
-            outfile.write("  Background.File-medium: %s\n" % (image_1024))
-            outfile.write("  Background.File-4-3: %s\n" % (image_43))
-            outfile.write("  Background.File-16-9: %s\n" % (image_169))
+            outfile.write("  Background.File-medium: {}\n".format(image_1024))
+            outfile.write("  Background.File-4-3: {}\n".format(image_43))
+            outfile.write("  Background.File-16-9: {}\n".format(image_169))
 
     # Refresh the wallpaper
-    cmd = 'sudo -u %s kdesk -w' % USER
+    cmd = 'sudo -u {user} kdesk -w'.format(user = USER)
     os.system(cmd)
     return 0


### PR DESCRIPTION
Originally, this was only about `about.py` to make translating strings easier for later gettext use by using a consistent string templating engine throughout the code.

Ok, admittedly the rest of this patch is bike-shedding. Not long ago, Python docs used to tell programmers that [% is deprecated and one should use .format() instead](https://docs.python.org/release/3.1.5/library/stdtypes.html#old-string-formatting-operations). But that warning [has been removed from newer Python docs](https://docs.python.org/3.5/library/string.html#formatspec) and so it looks like % isn't calling in the Spanish Inquisition these days.

But still.