### PR TITLE
To allow kano-world-launcher to have a splash screen, we need to call

### DIFF
--- a/bin/kano-settings
+++ b/bin/kano-settings
@@ -62,6 +62,8 @@ class MainWindow(ApplicationWindow):
         self.set_titlebar(self.top_bar)
         self.set_icon_name("kano-settings")
         self.connect("delete-event", Gtk.main_quit)
+        # In case we are called from kano-world-launcher, terminate splash
+        os.system('kano-stop-splash') 
         # Init to Home Screen
         HomeScreen(self, screen_number)
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kano-settings (1.3-2) unstable; urgency=low
+
+  * Allow kano-settings to close splash screens.
+
+ -- Team Kano <dev@kano.me>  Wed, 26 Nov 2014 14:45:00 +0000
+
 kano-settings (1.3-1) unstable; urgency=low
 
   * Added No Internet screen

--- a/debian/kano-settings.postinst
+++ b/debian/kano-settings.postinst
@@ -13,6 +13,7 @@ case "$1" in
     configure)
 
         # Create custom sudoers file
+        echo 'Defaults!/usr/bin/kano-settings env_keep += "SPLASH_PID SPLASH_START_TIME"' > $TMP_FILE
         echo "%sudo   ALL=(root) NOPASSWD: /usr/bin/kano-settings" > $TMP_FILE
         echo "%sudo   ALL=(root) NOPASSWD: /usr/bin/kano-settings-cli" >> $TMP_FILE
         echo "%sudo   ALL=(root) NOPASSWD: /usr/bin/regenerate-ssh-keys" >> $TMP_FILE


### PR DESCRIPTION
kano-stop-splash from settings.
Although it would be safe for kano-world to launch without this change,
the splash would temporarily cover the UI so we bump the version
of kano-settings to allow kano-profile to depend on it.
We also need to allow the splash identifier variables to pass to
kano-settings when it is run using sudo, for which purpose the sudoers
file is modified.