### PR TITLE
KanoDialog: use array instead of dict explicit button ordering

### DIFF
--- a/bin/kano-settings
+++ b/bin/kano-settings
@@ -90,22 +90,24 @@ class MainWindow(ApplicationWindow):
             kdialog = KanoDialog(
                 "Reboot?",
                 "Your Kano needs to reboot for changes to apply",
-                {
-                    "REBOOT NOW": {
-                        "return_value": 1,
-                        "color": "orange"
+                [
+                    {
+                        'label': "LATER",
+                        'color': 'grey',
+                        'return_value': False
                     },
-                    "LATER": {
-                        "return_value": 0,
-                        "color": "grey"
+                    {
+                        'label': "REBOOT NOW",
+                        'color': 'orange',
+                        'return_value': True
                     }
-                },
+                ],
                 parent_window=self.get_toplevel()
             )
 
             kdialog.set_action_background("grey")
-            response = kdialog.run()
-            if response == 1:
+            do_reboot_now = kdialog.run()
+            if do_reboot_now:
                 os.system("sudo reboot")
 
         Gtk.main_quit()

--- a/kano_settings/set_account.py
+++ b/kano_settings/set_account.py
@@ -115,18 +115,22 @@ class SetAccount(Gtk.Box):
             kdialog = kano_dialog.KanoDialog(
                 "Are you sure you want to delete the current user?",
                 "You will lose all the data on this account!",
-                {
-                    "OK": {
-                        "return_value": -1
+                [
+                    {
+                        'label': "CANCEL",
+                        'color': 'red',
+                        'return_value': False
                     },
-                    "CANCEL": {
-                        "return_value": 0
+                    {
+                        'label': "OK",
+                        'color': 'green',
+                        'return_value': True
                     }
-                },
+                ],
                 parent_window=self.win
             )
-            response = kdialog.run()
-            if response == -1:
+            do_delete_user = kdialog.run()
+            if do_delete_user:
                 self.disable_buttons()
                 # Delete current user
                 delete_user()
@@ -134,19 +138,22 @@ class SetAccount(Gtk.Box):
                 kdialog = kano_dialog.KanoDialog(
                     "To finish removing this account, you need to reboot",
                     "Do you want to reboot?",
-                    {
-                        "YES": {
-                            "return_value": -1
+                    [
+                        {
+                            'label': "LATER",
+                            'color': 'grey',
+                            'return_value': False
                         },
-                        "NO": {
-                            "return_value": 0,
-                            "color": "red"
+                        {
+                            'label': "REBOOT NOW",
+                            'color': 'orange',
+                            'return_value': True
                         }
-                    },
+                    ],
                     parent_window=self.win
                 )
-                response = kdialog.run()
-                if response == -1:
+                do_reboot_now = kdialog.run()
+                if do_reboot_now:
                     os.system("sudo reboot")
 
     # Disables both buttons and makes the temp 'flag' folder
@@ -239,15 +246,16 @@ class SetPassword(Template):
 
                 def done(title, description, success):
                     if success:
-                        response = create_success_dialog(title, description, self.win)
+                        create_success_dialog(title, description, self.win)
+                        do_try_again = False
                     else:
-                        response = create_error_dialog(title, description, self.win)
+                        do_try_again = create_error_dialog(title, description, self.win)
 
                     self.win.get_window().set_cursor(None)
                     self.kano_button.stop_spinner()
                     self.clear_text()
 
-                    if response == 0:
+                    if not do_try_again:
                         self.go_to_accounts()
 
                 GObject.idle_add(done, title, description, success)
@@ -291,18 +299,20 @@ class SetPassword(Template):
 
 def create_error_dialog(message1="Could not change password", message2="", win=None):
     kdialog = kano_dialog.KanoDialog(
-        message1, message2,
-        {
-            "TRY AGAIN":
+        message1,
+        message2,
+        [
             {
-                "return_value": -1
+                'label': "GO BACK",
+                'color': 'red',
+                'return_value': False
             },
-            "GO BACK":
             {
-                "return_value": 0,
-                "color": "red"
+                'label': "TRY AGAIN",
+                'color': 'green',
+                'return_value': True
             }
-        },
+        ],
         parent_window=win
     )
 
@@ -311,7 +321,10 @@ def create_error_dialog(message1="Could not change password", message2="", win=N
 
 
 def create_success_dialog(message1, message2, win):
-    kdialog = kano_dialog.KanoDialog(message1, message2,
-                                     parent_window=win)
+    kdialog = kano_dialog.KanoDialog(
+        message1,
+        message2,
+        parent_window=win
+    )
     response = kdialog.run()
     return response

--- a/kano_settings/set_advanced.py
+++ b/kano_settings/set_advanced.py
@@ -261,11 +261,11 @@ class SetPassword(Template):
 
                 # else, display try again dialog
                 else:
-                    response = self.create_dialog(
+                    do_try_again = self.create_dialog(
                         "Careful",
                         "The passwords don't match! Try again"
                     )
-                    if response == -1:
+                    if do_try_again:
                         if not self.parental_enabled:
                             self.entry1.set_text("")
                             self.entry2.set_text("")
@@ -291,15 +291,18 @@ class SetPassword(Template):
         kdialog = KanoDialog(
             message1,
             message2,
-            {
-                "TRY AGAIN": {
-                    "return_value": -1
+            [
+                {
+                    'label': "GO BACK",
+                    'color': 'red',
+                    'return_value': False
                 },
-                "GO BACK": {
-                    "return_value": 0,
-                    "color": "red"
+                {
+                    'label': "TRY AGAIN",
+                    'color': 'green',
+                    'return_value': True
                 }
-            },
+            ],
             parent_window=self.win
         )
 

--- a/kano_settings/set_overclock.py
+++ b/kano_settings/set_overclock.py
@@ -79,16 +79,18 @@ class SetOverclock(RadioButtonTemplate):
                         "the Pi behave unpredictably. Do you want to "
                         "continue?"
                     ),
-                    button_dict={
-                        "YES": {
-                            "color": "green",
-                            "return_value": True
+                    button_dict=[
+                        {
+                            'label': "NO",
+                            'color': 'red',
+                            'return_value': False
                         },
-                        "NO": {
-                            "color": "red",
-                            "return_value": False
+                        {
+                            'label': "YES",
+                            'color': 'green',
+                            'return_value': True
                         }
-                    },
+                    ],
                     parent_window=self.win
                 )
                 change_overclock = kdialog.run()

--- a/kano_settings/set_wifi.py
+++ b/kano_settings/set_wifi.py
@@ -311,12 +311,13 @@ class SetProxy(Gtk.Box):
                     kdialog = KanoDialog(
                         title,
                         description,
-                        {
-                            "OK":
+                        [
                             {
-                                "return_value": return_value
+                                'label': "OK",
+                                'color': 'green',
+                                'return_value': return_value
                             }
-                        },
+                        ],
                         parent_window=self.win
                     )
                     response = kdialog.run()


### PR DESCRIPTION
Most of Kano code uses KanoDialog with a dictionary to describe the buttons. But that can be a problem:

    response = KanoDialog(
        title_text = "Now click:",
        description_text = "Click a button.\nBut choose wisely.",
        button_dict={
            '#1': {
                'color': 'green',
                'return_value': 1
            },
            '#2': {
                'color': 'red',
                'return_value': 2
            },
            '#3': {
                'color': 'orange',
                'return_value': 3
            },
            '#4': {
                'color': 'grey',
                'return_value': 4
            }
        }
    ).run()

results in this:

![kano-four-buttons](https://cloud.githubusercontent.com/assets/1705654/6614947/b3c106fe-c89f-11e4-9465-a28617204b9b.png)

...because items in a dictionary are stored with a hash and the items' order is undefined.

A side effect for i18n is that the button order can be different for different locales:

    response = KanoDialog(
        title_text = _("Reboot?"),
        description_text = _("Reboot required."),
        button_dict={
            _("Later").upper(): {
                'color': 'grey',
                'return_value': False
            },
            _("Reboot now").upper(): {
                'color': 'orange',
                'return_value': True
            }
        }
    ).run()

With the same code, that orange REBOOT-Button will now appear to the right in English and to the left in German:

![kano-reboot](https://cloud.githubusercontent.com/assets/1705654/6615032/841d26fc-c8a0-11e4-9418-c99af37c8a3c.png) ![kano-neustart](https://cloud.githubusercontent.com/assets/1705654/6615034/88fd186c-c8a0-11e4-808e-cd9304fa29ef.png)

Luckily, it's possible to define an explicit button order using an array instead of a dictionary. That's what this patch does.

It also defines the colours for buttons. There is implicit button colouring with `kano_diaolog.py`, based on the English label text of the buttons, but that doesn't work with i18n.

But now comes a matter of taste you need to decide on:

Should it be ["CANCEL"-"OK" or "OK"-"CANCEL"](http://www.nngroup.com/articles/ok-cancel-or-cancel-ok/)?

[HID rules are arguing with each other](http://www.jurecuhalev.com/blog/2009/03/08/the-great-okcancel-button-dilemma/): Windows does OK-CANCEL. Apple and Gnome do CANCEL-OK. KDE isn't sure. [Designers argue.](http://uxmovement.com/buttons/why-ok-buttons-in-dialog-boxes-work-best-on-the-right/)

The [Gnome Human Interface Guidelines](https://developer.gnome.org/hig/stable/dialogs.html.en) say:

> When a dialog includes an affirmative and a cancel button, always ensure that the cancel button appears first, before the affirmative button. In left-to-right locales, this is on the left.
> This button order ensures that users become aware of, and are reminded of, the ability to cancel prior to encountering the affirmative button.

Makes sense. So this patch does CANCEL-OK / NO-YES / LATER-REBOOT.

But you decide.