### PR TITLE
Bootup sound script is displaying warning messages

### DIFF
--- a/etc/init.d/kano-bootup-sound
+++ b/etc/init.d/kano-bootup-sound
@@ -19,6 +19,8 @@
 # during the initial console boot messages, right after the alsa sound system is ready
 #
 
+. /lib/lsb/init-functions
+
 bootup_sound="/usr/share/kano-settings/media/sounds/kano_init.wav"
 
 case "$1" in
@@ -28,7 +30,7 @@ case "$1" in
         /etc/rc.audio
 
         # Ready to play the sound
-        aplay $bootup_sound & > /dev/null 2>1
+        aplay $bootup_sound > /dev/null 2>1 &
         rc=$?
         log_end_msg $rc
         ;;


### PR DESCRIPTION
 * Missing include file for LSB init scripts (log_msg and friends)
 * Fixed order of redirection parameter for aplay

This minor issues caused garbage noise to be displayed to the boot console.

cc @alex5imon @Ealdwulf @pazdera 