### PR TITLE
Prevent 640 480

### DIFF
--- a/bin/kano-settings-onboot
+++ b/bin/kano-settings-onboot
@@ -20,7 +20,7 @@ if __name__ == '__main__' and __package__ is None:
 from kano.utils import run_cmd, enforce_root
 from kano.logging import logger
 from kano_settings.system.display import get_status, get_model, set_hdmi_mode, \
-    get_edid
+    get_edid, is_mode_fallback
 from kano_settings.boot_config import set_config_value, set_config_comment, \
     get_config_comment, get_config_value, has_config_comment
 from kano_settings.system.audio import is_HDMI, set_to_HDMI
@@ -187,7 +187,8 @@ if check_clock_config_matches_chip():
     reboot_now = True
 
 # Reconfigure and reboot if the user requested safe mode
-if safe_boot_requested() and not is_safe_boot():
+# Or if the cable appears not to have been plugged in.
+if safe_boot_requested() and not is_safe_boot() or is_mode_fallback():
     logger.warn("Safe boot requested")
 
     # Backup the config file
@@ -211,6 +212,7 @@ if safe_boot_requested() and not is_safe_boot():
 
 # If we need to set anything to do with config.txt, reboot
 if reboot_now:
+    logger.sync()
     run_cmd('reboot -f')
     sys.exit()
 
@@ -275,6 +277,6 @@ changes = compare_and_set_mode() or compare_and_set_full_range() or \
 if changes:
     # write comment to config
     set_config_comment('kano_screen_used', model)
-
     # reboot
+    logger.sync()
     run_cmd('reboot -f')

--- a/kano_settings/system/display.py
+++ b/kano_settings/system/display.py
@@ -153,6 +153,24 @@ def get_status():
     return status
 
 
+def is_mode_fallback():
+    """ Is this the fallback mode which we get when the cable is unplugged?
+    """
+    status = get_status()
+    res = status['resolution']
+    parts = res.split('x')
+    if len(parts) != 2:
+        logger.error('Error parsing resolution')
+        return None
+    try:
+        (w, h) = map(int, parts)
+    except:
+        logger.error('Error parsing resolution')
+        return None
+
+    return w == 640 and h == 480
+
+
 def get_model():
     cmd = '/opt/vc/bin/tvservice -n'
     display_name, _, _ = run_cmd(cmd)

--- a/kano_settings/system/display.py
+++ b/kano_settings/system/display.py
@@ -22,21 +22,23 @@ xrefresh_path = '/usr/bin/xrefresh'
 
 
 def switch_display_safe_mode():
-   # Finds the first available display resolution that is safe
-   # and switches to this mode immediately
-   safe_resolution='1024x768'
+    # Finds the first available display resolution that is safe
+    # and switches to this mode immediately
+    safe_resolution = '1024x768'
 
-   try:
-      modes=list_supported_modes()
-      for m in modes:
-         resolution=m.split()[1]
-         if resolution == safe_resolution:
-            group=m.split()[0].split(':')[0]
-            mode=m.split()[0].split(':')[1]
-            logger.info ('Switching display to safe resolution {} (group={} mode={})'.format(resolution, group, mode))
+    try:
+        modes = list_supported_modes()
+        for m in modes:
+            resolution = m.split()[1]
+            if resolution == safe_resolution:
+                group = m.split()[0].split(':')[0]
+                mode = m.split()[0].split(':')[1]
+            logger.info(
+               'Switching display to safe resolution {} (group={} mode={})'
+               .format(resolution, group, mode))
             set_hdmi_mode_live(group, mode)
-   except:
-      logger.error ('Error switching display to safe mode')
+    except:
+        logger.error('Error switching display to safe mode')
 
 
 def launch_pipe():


### PR DESCRIPTION
This PR should fix #1723 . If we detect 640x480 mode, we use the same path as the 'safe mode' keys to reboot in 1024x768.