### PR TITLE
Moving settings to use the new kano-init API

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kano-settings (1.3-3) unstable; urgency=low
+
+  * support for the new kano-init
+
+ -- Team Kano <dev@kano.me>  Fri, 27 Mar 2015 15:05:00 +0000
+
 kano-settings (1.3-2) unstable; urgency=low
 
   * Added Option to restore users customized LXPanels to original settings

--- a/kano_settings/system/account.py
+++ b/kano_settings/system/account.py
@@ -13,14 +13,29 @@ from kano.utils import get_user_unsudoed, run_cmd
 from kano_world.functions import has_token
 
 
+class UserError(Exception):
+    pass
+
+
 # Needs sudo permission
 def add_user():
-    os.system("kano-init newuser")
+    # Imported locally to avoid circular dependency
+    try:
+        from kano_init.tasks.add_user import schedule_add_user
+        schedule_add_user()
+    except ImportError:
+        raise UserError("Unable to create the user. kano-init not found.")
 
 
 # Needs sudo permission
 def delete_user():
-    os.system('kano-init deleteuser {}'.format(get_user_unsudoed()))
+    # Imported locally to avoid circular dependency
+    try:
+        from kano_init.tasks.delete_user import schedule_delete_user
+        schedule_delete_user()
+    except ImportError:
+        raise UserError("Unable to delete the user. kano-init not found.")
+
     # back up profile
     if has_token():
         os.system("kano-sync --sync --backup")


### PR DESCRIPTION
Changing to the new kano-init interface.

I made all the imports conditional and while that's not ideal, there shouldn't be any problems with compatibility.

cc @alex5imon 