### PR TITLE
bin: Emit a tracking event

### DIFF
--- a/bin/kano-settings
+++ b/bin/kano-settings
@@ -27,6 +27,12 @@ from kano.gtk3.kano_combobox import KanoComboBox
 from kano.gtk3.scrolled_window import ScrolledWindow
 from kano.gtk3.top_bar import TopBar
 from kano.gtk3.kano_dialog import KanoDialog
+from kano_profile.tracker import track_data
+
+from kano_settings.system.audio import is_HDMI
+from kano_settings.config_file import get_setting
+from kano_settings.system.display import get_status
+
 
 MAX_STATE = 6
 init_state = -1
@@ -84,6 +90,20 @@ class MainWindow(ApplicationWindow):
             self.top_bar.prev_button.disconnect(self.prev_handler)
             self.prev_handler = None
 
+    def _trigger_tracking_event(self):
+        """ Generate a tracker event with some hardware settings.
+
+            This will send a track_date event called 'user-settings'
+            with the audio setting, parental lock level and display
+            configuration.
+        """
+
+        track_data('user-settings', {
+            'audio': 'hdmi' if is_HDMI() else 'analog',
+            'parental-lock-level': get_setting('Parental-level'),
+            'display': get_status()
+        })
+
     # On closing window, will alert if any of the listed booleans are True
     def close_window(self, button, event):
         if common.need_reboot:
@@ -109,6 +129,8 @@ class MainWindow(ApplicationWindow):
             do_reboot_now = kdialog.run()
             if do_reboot_now:
                 os.system("sudo reboot")
+
+        self._trigger_tracking_event()
 
         Gtk.main_quit()
 

--- a/debian/control
+++ b/debian/control
@@ -9,8 +9,8 @@ Build-Depends: debhelper (>= 9), build-essential, pkg-config, libgtk2.0-dev,
 Package: kano-settings
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, python, python-gi, dante-client,
-         kano-toolset (>= 1.3-12), kano-profile, gir1.2-gtk-3.0, libkdesk-dev,
-         sentry (>= 0.5-0), python-bs4
+         kano-toolset (>= 1.3-12), kano-profile (>= 1.3-7), gir1.2-gtk-3.0,
+         libkdesk-dev, sentry (>= 0.5-0), python-bs4
 Recommends: kano-fonts
 Description: Graphical tool to set different system settings
  This application is a GUI frontend to set multiple Kano OS functionalities


### PR DESCRIPTION
This happens when the window is closed, sending off the current

  * audio configuration,
  * display setup
  * and parental lock level.

Depends on the new tracker in profile.

Related to: https://github.com/KanoComputing/peldins/issues/1661

cc @carolineclark @alex5imon 

Tested on the pi and it seems to be working.