### PR TITLE
Remove call to /etc/rc.audio which no longer exists, and update comments...

### DIFF
--- a/etc/init.d/kano-bootup-sound
+++ b/etc/init.d/kano-bootup-sound
@@ -18,6 +18,7 @@
 # This debian init script plays a sound very early in the bootup process
 # during the initial console boot messages, right after the alsa sound system is ready
 #
+# alsa-utils, in the dependencies, sets volume and output device (Analog/HDMI)
 
 . /lib/lsb/init-functions
 
@@ -25,9 +26,6 @@ bootup_sound="/usr/share/kano-settings/media/sounds/kano_init.wav"
 
 case "$1" in
     start)
-
-        # Setup the sound output device (Analog/HDMI), as governed by kano-settings
-        /etc/rc.audio
 
         # Ready to play the sound
         aplay $bootup_sound > /dev/null 2>&1 &

--- a/etc/kano-rc.local
+++ b/etc/kano-rc.local
@@ -13,9 +13,9 @@
 # bits.
 #
 
-# FIXME: Commenting /etc/rc.audio, it is now called by kano-bootup-sound,
-# because rc.audio is parsed and controlled by kano-settings
-#/etc/rc.audio
+#
+# NB audio is no loger controlled here, we just rely on alsa-utils.
+#
 
 /etc/rc.network
 /etc/rc.overclock


### PR DESCRIPTION
There was a call to /etc/rc.audio which I missed removing in #247; it doesn't break anything but produces an error message at boot. This PR removes it.