### PR TITLE
Enabling ondemand mode to RPI2 4 CPU cores

### DIFF
--- a/etc/rc.overclock
+++ b/etc/rc.overclock
@@ -12,16 +12,20 @@
 # Ondemand cpu frequency will be enabled in the kernel. Setup the up-threshold now.
 
 threshold=70
+mode="performance"
 
-echo "ondemand" > /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
+echo "$mode" > /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
 
-# If more cores are available, this is a RaspberryPI 2
+# If more cores are available, this a RaspberryPI 2
 if [ -d "/sys/devices/system/cpu/cpu1/" ]; then
 
     for cpu in /sys/devices/system/cpu/cpu[1-3]*;
     do
-	echo -n "ondemand" > $cpu/cpufreq/scaling_governor
+	echo -n "$mode" > $cpu/cpufreq/scaling_governor
     done
 fi
 
-echo $threshold > /sys/devices/system/cpu/cpufreq/ondemand/up_threshold
+# Threshold only makes sense in "ondemand" mode
+if [ "$mode" = "ondemand" ]; then
+    echo "$threshold" > /sys/devices/system/cpu/cpufreq/ondemand/up_threshold
+fi

--- a/etc/rc.overclock
+++ b/etc/rc.overclock
@@ -10,5 +10,18 @@
 #
 
 # Ondemand cpu frequency will be enabled in the kernel. Setup the up-threshold now.
+
+threshold=70
+
 echo "ondemand" > /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
-echo 70 > /sys/devices/system/cpu/cpufreq/ondemand/up_threshold
+
+# If more cores are available, this is a RaspberryPI 2
+if [ -d "/sys/devices/system/cpu/cpu1/" ]; then
+
+    for cpu in /sys/devices/system/cpu/cpu[1-3]*;
+    do
+	echo -n "ondemand" > $cpu/cpufreq/scaling_governor
+    done
+fi
+
+echo $threshold > /sys/devices/system/cpu/cpufreq/ondemand/up_threshold


### PR DESCRIPTION
 * Even thought KanoOS kernel has it by default,
   we are forcing the "ondemand" operation mode to the rest
   of the CPU cores