### PR TITLE
Set default value for Country dropdown

### DIFF
--- a/kano_settings/set_keyboard.py
+++ b/kano_settings/set_keyboard.py
@@ -282,6 +282,10 @@ class SetKeyboard(Template):
         self.kano_button.set_sensitive(False)
         self.fill_countries_combo(self.selected_continent_hr)
 
+        # Use the first country as the default value for country combo
+        self.countries_combo.set_selected_item_index(0)
+        self.on_country_changed(self.countries_combo)
+
     def on_country_changed(self, combo):
 
         # making sure the country has been set

--- a/kano_settings/set_keyboard.py
+++ b/kano_settings/set_keyboard.py
@@ -2,7 +2,7 @@
 
 # set_keyboard.py
 #
-# Copyright (C) 2014 Kano Computing Ltd.
+# Copyright (C) 2014, 2015 Kano Computing Ltd.
 # License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
 #
 
@@ -250,7 +250,7 @@ class SetKeyboard(Template):
         self.variants_combo.set_selected_item_index(0)
 
     def set_variants_to_mac_layout(self):
-        
+
         # If the country is the United States, select the generic setting
         if self.selected_country_hr.upper() == "UNITED STATES":
             self.set_variants_to_generic()
@@ -302,7 +302,7 @@ class SetKeyboard(Template):
         if variants is not None:
             for v in variants:
                 self.variants_combo.append(v[0])
-        
+
         # if kano keyboard is connected, change to Mac layout
         kano_keyboard = detect_kano_keyboard()
 


### PR DESCRIPTION
This PR sets the default country to the first one in the available list. This way after changing the continent instead of getting empty dropdown menus for country and consequently for the "advanced options"