### PR TITLE
Add disconnect wifi option

### DIFF
--- a/bin/kano-wifi-gui
+++ b/bin/kano-wifi-gui
@@ -9,8 +9,24 @@
 # An alternative to kano-wifi console tool.
 #
 
+
+"""
+kano-wifi-gui shows the different screens for connecting and disconnecting to
+the internet.
+
+Usage:
+  kano-wifi-gui [-d]
+  kano-wifi-gui <screen>
+Options:
+   -h, --help       Show this message.
+   -d, --disconnect
+"""
+
+
 import sys
 import os
+import docopt
+
 from gi.repository import Gtk, GObject
 
 if __name__ == '__main__' and __package__ is None:
@@ -26,6 +42,7 @@ from kano.gtk3.apply_styles import (
     apply_common_to_screen, apply_styling_to_screen
 )
 from kano_wifi_gui.SpinnerScreen import SpinnerScreen
+from kano_wifi_gui.NetworkScreen import disconnect_dialog
 from kano_wifi_gui.paths import css_dir
 from kano.network import is_internet, is_ethernet_plugged, is_device
 
@@ -127,8 +144,11 @@ if __name__ == '__main__':
         print 'You need to run as root'
         sys.exit(1)
 
-    GObject.threads_init()
-
-    win = KanoWifiGui()
-    win.connect("delete-event", Gtk.main_quit)
-    Gtk.main()
+    args = docopt.docopt(__doc__)
+    if args['--disconnect']:
+        disconnect_dialog()
+    else:
+        GObject.threads_init()
+        win = KanoWifiGui()
+        win.connect("delete-event", Gtk.main_quit)
+        Gtk.main()

--- a/kano_wifi_gui/NetworkScreen.py
+++ b/kano_wifi_gui/NetworkScreen.py
@@ -28,7 +28,8 @@ from kano.gtk3.buttons import OrangeButton
 def disconnect_dialog(wiface='wlan0', win=None):
     disconnect(wiface)
     kdialog = KanoDialog(
-        "Successfully disconnected from the internet",
+        # Text from the content team.
+        "Disconnect complete - you're now offline.",
         parent_window=win
     )
     kdialog.run()

--- a/kano_wifi_gui/NetworkScreen.py
+++ b/kano_wifi_gui/NetworkScreen.py
@@ -9,7 +9,7 @@
 
 import os
 import threading
-from gi.repository import Gtk, GObject
+from gi.repository import Gtk, GObject, Gdk
 
 from kano.gtk3.heading import Heading
 from kano.gtk3.scrolled_window import ScrolledWindow
@@ -28,7 +28,7 @@ from kano.gtk3.buttons import OrangeButton
 def disconnect_dialog(wiface='wlan0', win=None):
     disconnect(wiface)
     kdialog = KanoDialog(
-        "Successfully disconnected from the InterWebs",
+        "Successfully disconnected from the internet",
         parent_window=win
     )
     kdialog.run()
@@ -205,7 +205,6 @@ class NetworkScreen(Gtk.Box):
             network_info_dict = network_info()
             network = network_info_dict.keys()[0]
             network_name = network_info_dict[network]["nice_name"]
-            print "network_info_dict = {}".format(network_info_dict)
 
         if has_internet and network_name is not "Ethernet":
             disconnect_button = OrangeButton("Disconnect")
@@ -218,8 +217,16 @@ class NetworkScreen(Gtk.Box):
         return buttonbox
 
     def launch_disconnect_dialog(self, widget=None):
+        watch_cursor = Gdk.Cursor(Gdk.CursorType.WATCH)
+        self.win.get_window().set_cursor(watch_cursor)
+
+        # Force the spinner to show on the window.
+        while Gtk.events_pending():
+            Gtk.main_iteration()
+
         disconnect_dialog(self.wiface, self.win)
 
+        self.win.get_window().set_cursor(None)
         # Reload networks - this is a lazy way of removing the tick next to the
         # connected network
         self.go_to_spinner_screen()

--- a/kano_wifi_gui/NetworkScreen.py
+++ b/kano_wifi_gui/NetworkScreen.py
@@ -20,7 +20,18 @@ from kano_wifi_gui.misc import tick_icon
 from kano.logging import logger
 from kano_wifi_gui.paths import media_dir
 from kano_wifi_gui.PasswordScreen import PasswordScreen
-from kano.network import connect, is_connected, KwifiCache
+from kano.network import (connect, is_connected, KwifiCache, disconnect,
+                          is_internet, network_info)
+from kano.gtk3.buttons import OrangeButton
+
+
+def disconnect_dialog(wiface='wlan0', win=None):
+    disconnect(wiface)
+    kdialog = KanoDialog(
+        "Successfully disconnected from the InterWebs",
+        parent_window=win
+    )
+    kdialog.run()
 
 
 class NetworkScreen(Gtk.Box):
@@ -177,7 +188,6 @@ class NetworkScreen(Gtk.Box):
         self.connect_btn.connect('clicked', self.first_time_connect)
         self.connect_btn.set_sensitive(False)
         self.refresh_btn = self.create_refresh_button()
-        blank_label = Gtk.Label("")
 
         # For now, show both connect and refresh buttons
         buttonbox = Gtk.ButtonBox()
@@ -185,9 +195,34 @@ class NetworkScreen(Gtk.Box):
         buttonbox.set_spacing(10)
         buttonbox.pack_start(self.refresh_btn, False, False, 0)
         buttonbox.pack_start(self.connect_btn, False, False, 0)
-        buttonbox.pack_start(blank_label, False, False, 0)
+
+        # If we are connected to the internet, add a diconnect option.
+        # Otherwise, leave it blank.
+        # Use is_connected to get details about whether connected to ethernet?
+        has_internet = is_internet()
+
+        if has_internet:
+            network_info_dict = network_info()
+            network = network_info_dict.keys()[0]
+            network_name = network_info_dict[network]["nice_name"]
+            print "network_info_dict = {}".format(network_info_dict)
+
+        if has_internet and network_name is not "Ethernet":
+            disconnect_button = OrangeButton("Disconnect")
+            disconnect_button.connect('clicked', self.launch_disconnect_dialog)
+            buttonbox.pack_start(disconnect_button, False, False, 0)
+        else:
+            blank_label = Gtk.Label("")
+            buttonbox.pack_start(blank_label, False, False, 0)
 
         return buttonbox
+
+    def launch_disconnect_dialog(self, widget=None):
+        disconnect_dialog(self.wiface, self.win)
+
+        # Reload networks - this is a lazy way of removing the tick next to the
+        # connected network
+        self.go_to_spinner_screen()
 
     def create_refresh_button(self):
         '''Create the refresh button. This it quite involved as you have

--- a/lxpanel-plugin-internet/kano_internet.c
+++ b/lxpanel-plugin-internet/kano_internet.c
@@ -31,6 +31,7 @@
 #define RECONNECT_CMD "sudo /usr/bin/kano-connect -c wlan0"
 #define SOUND_CMD "/usr/bin/aplay /usr/share/kano-media/sounds/kano_open_app.wav"
 #define PLUGIN_TOOLTIP "Internet status"
+#define DISCONNECT_CMD "sudo /usr/bin/kano-wifi-gui --disconnect"
 
 #define MINUTE 60
 
@@ -170,6 +171,14 @@ void connect_clicked(GtkWidget *widget)
     launch_cmd(SOUND_CMD, NULL);
 }
 
+void disconnect_clicked(GtkWidget *widget)
+{
+    /* Run disconnect script */
+    launch_cmd(DISCONNECT_CMD, "kano-wifi-gui");
+    /* Play sound */
+    launch_cmd(SOUND_CMD, NULL);
+}
+
 static gboolean show_menu(GtkWidget *widget, GdkEventButton *event, kano_internet_plugin_t *plugin)
 {
     GtkWidget *menu = gtk_menu_new();
@@ -197,7 +206,14 @@ static gboolean show_menu(GtkWidget *widget, GdkEventButton *event, kano_interne
         /* Internet working correctly */
         GtkWidget *internet_item = gtk_menu_item_new_with_label("Connected");
         gtk_menu_append(GTK_MENU(menu), internet_item);
+
+        /* Option to disconnect */
+        GtkWidget *disconnect_item = gtk_menu_item_new_with_label("Disconnect");
+        g_signal_connect(disconnect_item, "activate", G_CALLBACK(disconnect_clicked), NULL);
+        gtk_menu_append(GTK_MENU(menu), disconnect_item);
+
         gtk_widget_show(internet_item);
+        gtk_widget_show(disconnect_item);
     }
     else
     {

--- a/lxpanel-plugin-internet/kano_internet.c
+++ b/lxpanel-plugin-internet/kano_internet.c
@@ -229,10 +229,10 @@ static gboolean show_menu(GtkWidget *widget, GdkEventButton *event, kano_interne
 
     } else {
         /* Internet working correctly, change the picture accordingly */
-        GtkWidget *internet_item = gtk_menu_item_new_with_label("Connected");
+        GtkWidget *header_item = gtk_menu_item_new_with_label("Connected");
         gtk_widget_set_sensitive(header_item, FALSE);
-        gtk_menu_append(GTK_MENU(menu), internet_item);
-        gtk_widget_show(internet_item);
+        gtk_menu_append(GTK_MENU(menu), header_item);
+        gtk_widget_show(header_item);
 
         if (strcmp(internet, "WIRELESS") == 0) {
             /* Add the option to disconnect from the internet. */

--- a/lxpanel-plugin-internet/kano_internet.c
+++ b/lxpanel-plugin-internet/kano_internet.c
@@ -207,12 +207,6 @@ static gboolean show_menu(GtkWidget *widget, GdkEventButton *event, kano_interne
         return FALSE;
     }
 
-    /* Create the menu items */
-    header_item = gtk_menu_item_new_with_label("Internet status");
-    gtk_widget_set_sensitive(header_item, FALSE);
-    gtk_menu_append(GTK_MENU(menu), header_item);
-    gtk_widget_show(header_item);
-
     // update the internet icon status
     internet_status(plugin);
 
@@ -220,7 +214,13 @@ static gboolean show_menu(GtkWidget *widget, GdkEventButton *event, kano_interne
     gchar* internet = plugin->internet_available;
 
     if (strcmp(internet, "NOT CONNECTED") == 0) {
-        /* Change the widget's picture and add the option to try and connect to internet */
+
+        /* Change the widget's picture, menu title and add the option to try and connect to internet */
+        header_item = gtk_menu_item_new_with_label("Not connected");
+        gtk_widget_set_sensitive(header_item, FALSE);
+        gtk_menu_append(GTK_MENU(menu), header_item);
+        gtk_widget_show(header_item);
+
         GtkWidget *internet_item = gtk_image_menu_item_new_with_label("Connect");
         g_signal_connect(internet_item, "activate", G_CALLBACK(connect_clicked), NULL);
         gtk_menu_append(GTK_MENU(menu), internet_item);
@@ -230,11 +230,12 @@ static gboolean show_menu(GtkWidget *widget, GdkEventButton *event, kano_interne
     } else {
         /* Internet working correctly, change the picture accordingly */
         GtkWidget *internet_item = gtk_menu_item_new_with_label("Connected");
+        gtk_widget_set_sensitive(header_item, FALSE);
         gtk_menu_append(GTK_MENU(menu), internet_item);
         gtk_widget_show(internet_item);
 
         if (strcmp(internet, "WIRELESS") == 0) {
-            /* Add the option to disconnect in the menu */
+            /* Add the option to disconnect from the internet. */
             GtkWidget *disconnect_item = gtk_menu_item_new_with_label("Disconnect");
             g_signal_connect(disconnect_item, "activate", G_CALLBACK(disconnect_clicked), NULL);
             gtk_menu_append(GTK_MENU(menu), disconnect_item);

--- a/lxpanel-plugin-internet/kano_internet.c
+++ b/lxpanel-plugin-internet/kano_internet.c
@@ -114,7 +114,7 @@ static gboolean internet_status(kano_internet_plugin_t *plugin) {
      */
 
     // Execute is_internet command. 0 is internet, non zero means no internet
-    int internet = system(INTERNET_CMD);
+    int internet = WEXITSTATUS(system(INTERNET_CMD));
 
     if (internet == 0) {
         gtk_image_set_from_file(GTK_IMAGE(plugin->icon), WIFI_ICON);


### PR DESCRIPTION
The command ```sudo kano-wifi-gui --disconnect``` will now disconnect the user from the internet if they are connected to WiFi.

Added a disconnect option to the internet widget.
![kano-screenshot-mon-may-11-17-58-30](https://cloud.githubusercontent.com/assets/5319573/7570385/af4a8c7a-f807-11e4-8ca0-ec1819d5a5de.png)

When clicking disconnect, this launches a dialog once the process is finished:
![kano-screenshot-mon-may-11-18-00-02](https://cloud.githubusercontent.com/assets/5319573/7570549/e1933640-f808-11e4-9b13-f2c9309e72aa.png)

Added a beautiful Disconnect button to the GUI when the user is connected via WiFi.  Will change when @TommySaehl has a design, the placement does look a bit weird.
![kano-screenshot-mon-may-11-18-12-31](https://cloud.githubusercontent.com/assets/5319573/7570621/620a1eb0-f809-11e4-8af4-fed821e35d8f.png)

This is nearly complete, but needs some more refining with ethernet connections - for example, the Disconnect option in the internet widget should only be shown when connected to WiFi.

Needs this pull request to work: https://github.com/KanoComputing/kano-toolset/pull/131