### PR TITLE
i18n: Add functionality (and tests) to set locale

### DIFF
--- a/kano_settings/system/locale.py
+++ b/kano_settings/system/locale.py
@@ -1,0 +1,149 @@
+#
+# locale.py
+#
+# Copyright (C) 2015 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+#
+# Set configuration for i18n locale
+#
+# Note: Several conflicting conventions are used by the system tools for the
+# naming of locales. Here, everything will be converted to use UTF-8 and take
+# the standard format
+#
+#     <language>_<REGION>.UTF-8
+#
+
+
+# TODO: Make this safety measure cleaner
+if not hasattr(__builtins__, '_'):
+    def _(s):
+        return s
+
+import re
+import os
+from kano.utils import run_cmd, read_file_contents, sed, enforce_root, \
+    read_file_contents_as_lines, get_user_unsudoed, get_home_by_username, \
+    chown_path
+
+SUPPORTED_LIST_FILE = '/usr/share/i18n/SUPPORTED'
+LOCALE_GEN_FILE = '/etc/locale.gen'
+XSESSION_RC_FILE = os.path.join(get_home_by_username(get_user_unsudoed()),
+                                '.xsessionrc')
+LOCALE_PARAMS = [
+    # 'LANG',  # Determines the default locale in the absence of other locale related environment variables
+    'LANGUAGE',  #
+    'LC_ADDRESS',  # Convention used for formatting of street or postal addresses
+    'LC_COLLATE',  # Collation order
+    'LC_CTYPE',  # Character classification and case conversion
+    'LC_MONETARY',  # Monetary formatting
+    'LC_MEASUREMENT',  # Default measurement system used within the region
+    'LC_MESSAGES',  # Format of interactive words and responses
+    'LC_NUMERIC',  # Numeric formatting
+    'LC_PAPER',  # Default paper size for region
+    'LC_RESPONSE',  # Determines how responses (such as Yes and No) appear in the local language
+    'LC_TELEPHONE',  # Conventions used for representation of telephone numbers
+    'LC_TIME'  # Date and time formats
+]
+
+
+def is_locale_valid(locale):
+    """
+    The supported file list (UTF-8) entries take the form
+        <language>_<REGION>[.\s]UTF-8(\sUTF-8)?
+    """
+
+    return re.search(standard_locale_to_genfile_entry(locale),
+                     read_file_contents(SUPPORTED_LIST_FILE))
+
+
+def is_locale_installed(locale):
+    """
+    The `locale --all-locales` command returns entries of the form
+        <language>_<REGION>.utf8
+    """
+
+    locale = ensure_utf_locale(locale)
+
+    locales, dummy, dummy = run_cmd('locale --all-locales')
+    locales = [ensure_utf_locale(l) for l in locales.splitlines()]
+
+    return locale in locales
+
+
+def ensure_utf_locale(locale):
+    return re.sub(r'^([a-z]{2}_[A-Z]{2})(?:\.|$).*', r'\1.UTF-8', locale)
+
+
+def standard_locale_to_genfile_entry(locale):
+    '''
+    The locale gen file (UTF-8) entries take the form
+        <language>_<REGION>[.\s]UTF-8(\sUTF-8)?
+    '''
+
+    locale = ensure_utf_locale(locale)
+    locale_code = locale.split('.')[0]
+
+    return locale_code + r'[\.\s]UTF-8(\sUTF-8)?'
+
+
+def install_locale(locale):
+    locale = ensure_utf_locale(locale)
+
+    if not is_locale_valid(locale):
+        print 'locale not valid', locale
+        return False
+
+    enforce_root(_('You need to be root to change install a locale'))
+
+    genfile_locale = standard_locale_to_genfile_entry(locale)
+    sed(r'^# ({})'.format(genfile_locale), r'\1', LOCALE_GEN_FILE)
+    run_cmd('locale-gen')
+
+
+def uninstall_locale(locale):
+    locale = ensure_utf_locale(locale)
+
+    if not is_locale_valid(locale):
+        print 'locale not valid'
+        return False
+
+    enforce_root(_('You need to be root to change install a locale'))
+
+    genfile_locale = standard_locale_to_genfile_entry(locale)
+    sed('^({})'.format(genfile_locale), r'# \1', LOCALE_GEN_FILE)
+    run_cmd('locale-gen')
+
+
+def set_locale_param(param, locale, skip_check=False):
+    if not skip_check and not is_locale_installed(locale):
+        install_locale(locale)
+
+    param_found = False
+    new_param_line = 'export {}={}'.format(param, locale)
+    new_config_file = []
+
+    if os.path.exists(XSESSION_RC_FILE):
+        xsession_file = read_file_contents_as_lines(XSESSION_RC_FILE)
+
+        for line in xsession_file:
+            if param in line:
+                line = new_param_line
+                param_found = True
+
+            new_config_file.append(line)
+
+    if not param_found:
+        new_config_file.append(new_param_line)
+
+    with open(XSESSION_RC_FILE, 'w') as conf_file:
+        conf_file.write('\n'.join(new_config_file))
+
+    chown_path(XSESSION_RC_FILE)
+
+
+def set_locale(locale):
+    if not is_locale_installed(locale):
+        install_locale(locale)
+
+    for param in LOCALE_PARAMS:
+        set_locale_param(param, locale, skip_check=True)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,9 @@
+#
+# __init__.py
+#
+# Copyright (C) 2015 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+#
+
+__author__ = 'Kano Computing Ltd.'
+__email__ = 'dev@kano.me'

--- a/tests/i18n/__init__.py
+++ b/tests/i18n/__init__.py
@@ -1,0 +1,9 @@
+#
+# __init__.py
+#
+# Copyright (C) 2015 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+#
+
+__author__ = 'Kano Computing Ltd.'
+__email__ = 'dev@kano.me'

--- a/tests/i18n/test_locale.py
+++ b/tests/i18n/test_locale.py
@@ -1,0 +1,223 @@
+#
+# test_locale.py
+#
+# Copyright (C) 2015 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+#
+# This module tests the detection of all RaspberryPI models
+#
+
+
+import unittest
+import sys
+import os
+
+sys.path.insert(1, os.path.abspath(
+    os.path.join(os.path.dirname(__file__), '..')))
+
+import kano_settings.system.locale as locale
+import kano.utils as utils
+
+from tests.tools import test_print, mock_file
+
+
+print '''
+***************************
+******* Test Locale *******
+***************************
+
+To for the tests to be fair, ensure that you have installed:
+    en_US.UTF-8
+    en_GB.UTF-8
+And that you have removed:
+    ru_RU.UTF-8
+    aa_ER.UTF-8
+'''
+
+
+class EnsureUTFLocale(unittest.TestCase):
+
+    def test_with_utf_suffix(self):
+        self.assertEqual(locale.ensure_utf_locale('en_GB.UTF-8'), 'en_GB.UTF-8')
+
+    def test_without_utf_suffix(self):
+        self.assertEqual(locale.ensure_utf_locale('en_GB'), 'en_GB.UTF-8')
+
+    def test_with_wrong_suffix(self):
+        self.assertEqual(locale.ensure_utf_locale('en_GB.ISO-8859-1'),
+                         'en_GB.UTF-8')
+
+
+class StandardLocaleToGenfileEntry(unittest.TestCase):
+
+    def test(self):
+        test_locale = locale.ensure_utf_locale('en_GB')
+
+        self.assertEqual(locale.standard_locale_to_genfile_entry(test_locale),
+                         r'en_GB[\.\s]UTF-8(\sUTF-8)?')
+
+
+
+class IsLocaleValid(unittest.TestCase):
+
+    def test_is_en_US_valid(self):
+        self.assertTrue(locale.is_locale_valid('en_US.UTF-8'))
+
+    def test_is_en_GB_valid(self):
+        self.assertTrue(locale.is_locale_valid('en_GB.UTF-8'))
+
+    def test_is_random_string_valid(self):
+        self.assertFalse(locale.is_locale_valid('some_invalid_locale'))
+
+
+class IsLocaleInstalled(unittest.TestCase):
+
+    def test_is_en_US_installed(self):
+        self.assertTrue(locale.is_locale_installed('en_US.UTF-8'))
+
+    def test_is_en_GB_installed(self):
+        self.assertTrue(locale.is_locale_installed('en_GB.UTF-8'))
+
+    def test_is_ru_RU_installed(self):
+        self.assertFalse(locale.is_locale_installed('ru_RU.UTF-8'))
+
+    def test_is_aa_ER_installed(self):
+        self.assertFalse(locale.is_locale_installed('aa_ER.UTF-8'))
+
+    def test_is_random_string_installed(self):
+        self.assertFalse(locale.is_locale_installed('some_ininstalled_locale'))
+
+
+class InstallLocale(unittest.TestCase):
+
+    def test_install_locale(self):
+        test_locale = 'aa_ER'
+        locale_already_installed = locale.is_locale_installed(test_locale)
+
+        if locale_already_installed:
+            test_print('Locale already installed so uninstalling...')
+            locale.uninstall_locale(test_locale)
+
+            if locale.is_locale_installed(test_locale):
+                test_print('ERROR: Locale could not be removed')
+                return
+
+        locale.install_locale(test_locale)
+
+        self.assertTrue(locale.is_locale_installed(test_locale))
+
+        # Revert the state
+        if not locale_already_installed:
+            test_print('Restoring original locale state')
+            locale.uninstall_locale(test_locale)
+
+
+class UninstallLocale(unittest.TestCase):
+
+    def test_uninstall_locale(self):
+        test_locale = 'aa_ER'
+        locale_already_installed = locale.is_locale_installed(test_locale)
+
+        if not locale_already_installed:
+            test_print('Locale not installed so installing...')
+            locale.install_locale(test_locale)
+
+            if not locale.is_locale_installed(test_locale):
+                test_print('ERROR: Locale could not be installed')
+                return
+
+        locale.uninstall_locale(test_locale)
+
+        self.assertFalse(locale.is_locale_installed(test_locale))
+
+        # Revert the state
+        if locale_already_installed:
+            test_print('Restoring original locale state')
+            locale.install_locale(test_locale)
+
+
+class SetLocaleParam(unittest.TestCase):
+
+    def run_test_for_param(self, param):
+        with mock_file(locale.XSESSION_RC_FILE):
+            test_locale = 'en_US.UTF-8'
+            config_line = 'export {}={}'.format(param, test_locale)
+            locale.set_locale_param(param, test_locale)
+
+            config = utils.read_file_contents_as_lines(locale.XSESSION_RC_FILE)
+
+            self.assertTrue(config_line in config)
+
+    def test_xsession_rc_file_path(self):
+        self.assertEqual(locale.XSESSION_RC_FILE,
+                         os.path.join('/home', utils.get_user_unsudoed(),
+                                      '.xsessionrc'))
+
+    def test_LANGUAGE_set(self):
+        self.run_test_for_param('LANGUAGE')
+
+    def test_LC_ADDRESS_set(self):
+        self.run_test_for_param('LC_ADDRESS')
+
+    def test_LC_COLLATE_set(self):
+        self.run_test_for_param('LC_COLLATE')
+
+    def test_LC_CTYPE_set(self):
+        self.run_test_for_param('LC_CTYPE')
+
+    def test_LC_MONETARY_set(self):
+        self.run_test_for_param('LC_MONETARY')
+
+    def test_LC_MEASUREMENT_set(self):
+        self.run_test_for_param('LC_MEASUREMENT')
+
+    def test_LC_MESSAGES_set(self):
+        self.run_test_for_param('LC_MESSAGES')
+
+    def test_LC_NUMERIC_set(self):
+        self.run_test_for_param('LC_NUMERIC')
+
+    def test_LC_PAPER_set(self):
+        self.run_test_for_param('LC_PAPER')
+
+    def test_LC_RESPONSE_set(self):
+        self.run_test_for_param('LC_RESPONSE')
+
+    def test_LC_TELEPHONE_set(self):
+        self.run_test_for_param('LC_TELEPHONE')
+
+    def test_LC_TIME_set(self):
+        self.run_test_for_param('LC_TIME')
+
+
+class SetLocale(unittest.TestCase):
+
+    def test_set_locale(self):
+        with mock_file(locale.XSESSION_RC_FILE):
+            params = [
+                'LANGUAGE',
+                'LC_ADDRESS',
+                'LC_COLLATE',
+                'LC_CTYPE',
+                'LC_MONETARY',
+                'LC_MEASUREMENT',
+                'LC_MESSAGES',
+                'LC_NUMERIC',
+                'LC_PAPER',
+                'LC_RESPONSE',
+                'LC_TELEPHONE',
+                'LC_TIME'
+            ]
+
+            test_locale = 'en_US.UTF-8'
+            config_lines = [
+                'export {}={}'.format(param, test_locale) for param in params
+            ]
+            locale.set_locale(test_locale)
+
+            config = utils.read_file_contents_as_lines(locale.XSESSION_RC_FILE)
+            for line in config_lines:
+                if line not in config:
+                    self.assertFalse(True)
+
+            self.assertTrue(True)

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,0 +1,27 @@
+#/usr/bin/python
+
+# test.py
+#
+# Copyright (C) 2015 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+#
+# Runs all the unit tests
+#
+
+
+import sys
+import os
+import unittest
+
+sys.path.insert(1, os.path.abspath(
+    os.path.join(os.path.dirname(__file__), '..')))
+
+
+SUITE = unittest.TestSuite()
+TESTS = [
+    'tests.i18n.test_locale'
+]
+
+for test in TESTS:
+    SUITE.addTest(unittest.defaultTestLoader.loadTestsFromName(test))
+unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -1,0 +1,36 @@
+#
+# tools.py
+#
+# Copyright (C) 2015 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+#
+# Useful functions for testing
+#
+
+
+import os
+import shutil
+from contextlib import contextmanager
+
+def test_print(s):
+    print '\n        ........{}'.format(s)
+
+
+@contextmanager
+def mock_file(file_path, mock_data=None):
+    original_file = file_path + '.orig'
+
+    if os.path.exists(file_path):
+        shutil.move(file_path, original_file)
+
+    if mock_data:
+        with open(file_path, 'w') as mock_file_handle:
+            mock_file_handle.write(mock_data)
+
+    yield
+
+    if os.path.exists(file_path):
+        os.remove(file_path)
+
+    if os.path.exists(original_file):
+        shutil.move(original_file, file_path)


### PR DESCRIPTION
To enable use of locales, add the functions which provide the ability to
set them using the settings toolset. This adds a functions to manage the
locales (installation, removal, setting the locale, checking that the
locale is valid, etc) and also provides unit tests to check each of
these functions.

@pazdera @convolu @skarbat 