### PR TITLE
Home refactor

### DIFF
--- a/bin/kano-settings
+++ b/bin/kano-settings
@@ -14,127 +14,13 @@ from gi.repository import Gtk, GObject
 GObject.threads_init()
 
 if __name__ == '__main__' and __package__ is None:
-    dir_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-    if dir_path != '/usr':
-        sys.path.insert(1, dir_path)
-
-import kano_settings.common as common
-from kano_settings.home_screen import HomeScreen, UnknownScreenError
-from kano.network import is_internet
-from kano.gtk3.apply_styles import apply_styling_to_screen, apply_common_to_screen
-from kano.gtk3.application_window import ApplicationWindow
-from kano.gtk3.kano_combobox import KanoComboBox
-from kano.gtk3.scrolled_window import ScrolledWindow
-from kano.gtk3.top_bar import TopBar
-from kano.gtk3.kano_dialog import KanoDialog
-from kano_profile.tracker import track_data
-
-from kano_settings.system.audio import is_HDMI
-from kano_settings.config_file import get_setting
-from kano_settings.system.display import get_status
+    DIR_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+    if DIR_PATH != '/usr':
+        sys.path.insert(1, DIR_PATH)
 
 
-MAX_STATE = 6
-init_state = -1
-
-
-# Window class
-class MainWindow(ApplicationWindow):
-    state = 0
-    last_level_visited = 0
-    width = 680
-    height = 405
-    CSS_PATH = os.path.join(common.css_dir, 'style.css')
-
-    def __init__(self, screen_number=None, screen_name=None):
-        # Check for internet, if screen is 12 means no internet
-        if screen_number == 12 or screen_name == 'no-internet':
-            common.has_internet = False
-        else:
-            common.has_internet = is_internet()
-
-        # Set combobox styling to the screen
-        # Is done here so we don't attach the styling multiple times when
-        # switching screens
-        apply_styling_to_screen(self.CSS_PATH)
-        apply_common_to_screen()
-        KanoComboBox.apply_styling_to_screen()
-        ScrolledWindow.apply_styling_to_screen(wide=True)
-
-        # Set window
-        ApplicationWindow.__init__(self, "Settings", self.width, self.height)
-        self.set_decorated(True)
-        self.top_bar = TopBar("Settings")
-        self.top_bar.set_close_callback(self.close_window)
-        self.prev_handler = None
-        self.set_titlebar(self.top_bar)
-        self.set_icon_name("kano-settings")
-        self.connect("delete-event", Gtk.main_quit)
-        # In case we are called from kano-world-launcher, terminate splash
-        os.system('kano-stop-splash')
-        # Init to Home Screen
-        HomeScreen(self, screen_number=screen_number, screen_name=screen_name)
-
-    def clear_win(self):
-        self.remove_main_widget()
-
-    def go_to_home(self, widget=None, event=None):
-        self.clear_win()
-        HomeScreen(self)
-
-    def change_prev_callback(self, callback):
-        # first time, no event attached
-        self.remove_prev_callback()
-        self.prev_handler = self.top_bar.prev_button.connect("button-release-event", callback)
-
-    def remove_prev_callback(self):
-        if self.prev_handler:
-            self.top_bar.prev_button.disconnect(self.prev_handler)
-            self.prev_handler = None
-
-    def _trigger_tracking_event(self):
-        """ Generate a tracker event with some hardware settings.
-
-            This will send a track_date event called 'user-settings'
-            with the audio setting, parental lock level and display
-            configuration.
-        """
-
-        track_data('user-settings', {
-            'audio': 'hdmi' if is_HDMI() else 'analog',
-            'parental-lock-level': get_setting('Parental-level'),
-            'display': get_status()
-        })
-
-    # On closing window, will alert if any of the listed booleans are True
-    def close_window(self, button, event):
-        if common.need_reboot:
-            kdialog = KanoDialog(
-                "Reboot?",
-                "Your Kano needs to reboot for changes to apply",
-                [
-                    {
-                        'label': "LATER",
-                        'color': 'grey',
-                        'return_value': False
-                    },
-                    {
-                        'label': "REBOOT NOW",
-                        'color': 'orange',
-                        'return_value': True
-                    }
-                ],
-                parent_window=self.get_toplevel()
-            )
-
-            kdialog.set_action_background("grey")
-            do_reboot_now = kdialog.run()
-            if do_reboot_now:
-                os.system("sudo reboot")
-
-        self._trigger_tracking_event()
-
-        Gtk.main_quit()
+from kano_settings.main_window import MainWindow
+from kano_settings.home_screen import UnknownScreenError
 
 
 def main(screen_number=None, screen_name=None):

--- a/bin/kano-settings
+++ b/bin/kano-settings
@@ -2,10 +2,10 @@
 
 # kano-settings
 #
-# Copyright (C) 2014 Kano Computing Ltd.
-# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+# Copyright (C) 2014-2015 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
 #
-# Main window class
+# Kano Settings executable
 #
 
 import os
@@ -46,9 +46,9 @@ class MainWindow(ApplicationWindow):
     height = 405
     CSS_PATH = os.path.join(common.css_dir, 'style.css')
 
-    def __init__(self, screen_number=None):
+    def __init__(self, screen_number=None, screen_name=None):
         # Check for internet, if screen is 12 means no internet
-        if screen_number == 12:
+        if screen_number == 12 or screen_name == 'no-internet':
             common.has_internet = False
         else:
             common.has_internet = is_internet()
@@ -73,7 +73,7 @@ class MainWindow(ApplicationWindow):
         # In case we are called from kano-world-launcher, terminate splash
         os.system('kano-stop-splash')
         # Init to Home Screen
-        HomeScreen(self, screen_number)
+        HomeScreen(self, screen_number=screen_number, screen_name=screen_name)
 
     def clear_win(self):
         self.remove_main_widget()
@@ -137,10 +137,10 @@ class MainWindow(ApplicationWindow):
         Gtk.main_quit()
 
 
-def main(screen_number=None):
+def main(screen_number=None, screen_name=None):
 
     # Create windown
-    MainWindow(screen_number)
+    MainWindow(screen_number=screen_number, screen_name=screen_name)
 
     # start the GTK+ processing loop
     Gtk.main()
@@ -151,10 +151,14 @@ if __name__ == "__main__":
     if os.environ['LOGNAME'] != 'root':
         exit("Error: Settings must be executed with root privileges")
 
-    if(len(sys.argv) > 1):
+    if len(sys.argv) > 1:
         try:
-            init_state = int(sys.argv[1])
-            main(init_state)
+            init_state = sys.argv[1]
+
+            if init_state.isdigit():
+                main(screen_number=int(init_state))
+            else:
+                main(screen_name=init_state)
         except UnknownScreenError:
             exit("Error: incorrect argument")
 

--- a/bin/kano-settings
+++ b/bin/kano-settings
@@ -17,7 +17,12 @@ if __name__ == '__main__' and __package__ is None:
     DIR_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
     if DIR_PATH != '/usr':
         sys.path.insert(1, DIR_PATH)
+        LOCALE_PATH = os.path.join(DIR_PATH, 'locale')
+    else:
+        LOCALE_PATH = None
 
+import kano_i18n.init
+kano_i18n.init.install('kano-settings', LOCALE_PATH)
 
 from kano_settings.main_window import MainWindow
 from kano_settings.home_screen import UnknownScreenError

--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, kano-connect (= ${binary:Version}),
          python, python-gi, dante-client, kano-toolset (>= 1.3-12),
          kano-profile (>= 1.3-7), gir1.2-gtk-3.0, libkdesk-dev, sentry (>= 0.5-0),
-         python-bs4, python-pycountry
+         python-bs4, python-pycountry, kano-i18n
 Recommends: kano-fonts
 Description: Graphical tool to set different system settings
  This application is a GUI frontend to set multiple Kano OS functionalities

--- a/kano_settings/home_screen.py
+++ b/kano_settings/home_screen.py
@@ -2,33 +2,17 @@
 
 # home_screen.py
 #
-# Copyright (C) 2014 Kano Computing Ltd.
-# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+# Copyright (C) 2014-2015 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
 #
 
 from gi.repository import Gtk
-
-from kano_settings.set_keyboard import choose_keyboard_screen
-from kano_settings.set_mouse import SetMouse
-from kano_settings.set_notifications import SetNotifications
-from kano_settings.set_font import SetFont
-from kano_settings.set_audio import SetAudio
-from kano_settings.set_display import SetDisplay
-from kano_settings.set_wifi import SetWifi, SetProxy
-from kano_settings.no_internet_screen import NoInternet
-from kano_settings.set_overclock import SetOverclock
-from kano_settings.set_account import SetAccount
-from kano_settings.set_about import SetAbout
-from kano_settings.set_advanced import SetAdvanced
-from kano_settings.set_appearance import SetAppearance
-from kano_settings.set_wallpaper import FirstBootSetWallpaper
-
-import kano_settings.common as common
-from kano_settings.components.menu_button import Menu_button
-from kano_settings.config_file import get_setting
+import math
 
 from kano.gtk3.scrolled_window import ScrolledWindow
-from kano.utils import get_user_unsudoed
+
+from kano_settings.screens import SCREENS
+
 
 
 class UnknownScreenError(Exception):
@@ -36,165 +20,102 @@ class UnknownScreenError(Exception):
 
 
 class HomeScreen(Gtk.Box):
+    _DISPLAYED_SCREENS = SCREENS.get_screens_on_home()
 
-    names = ["Keyboard", "Mouse", "Audio", "Display", "Wifi", "Overclocking",
-             "Account", "Appearance", "Font", "Advanced", "About",
-             "Notifications"]
-    custom_info = ["Keyboard-country-human", "Mouse", "Audio", None, None,
-                   "Overclocking", None, "Wallpaper", "Font"]
+    def __init__(self, win, screen_number=None, screen_name=None):
+        self.win = win
 
-    def __init__(self, win, screen_number=None):
         # Check if we want to initialise another window first
+        if screen_name:
+            self.go_to_screen(screen_name)
+            return
+
         if screen_number is not None:
-            try:
-                self.state_to_widget(screen_number)(win)
-            except KeyError:
-                msg = "State {} not recognised".format(screen_number)
-                raise UnknownScreenError(msg)
+            self.go_to_screen_number(screen_number)
             return
 
         Gtk.Box.__init__(self)
 
-        self.win = win
         self.win.set_main_widget(self)
         self.win.top_bar.disable_prev()
         self.win.remove_prev_callback()
 
         self.width = 640
         self.height = 304
-        self.number_of_columns = 2
+        self._col_count = 2
 
-        self.generate_grid()
-        self.pack_start(self.scrolledwindow, True, True, 0)
+        scrolled_window = self._generate_grid()
+        self.pack_start(scrolled_window, True, True, 0)
 
         self.win.show_all()
 
-    def generate_grid(self):
-        buttons = []
-        self.labels = []
 
-        # names at top of file
-        for x in range(len(self.names)):
-            self.item = Menu_button(self.names[x], '')
-            self.labels.append(self.item.description)
-            # Update the state of the button, so we know which button has been
-            # clicked on.
-            self.item.button.state = x
-            self.item.button.connect("clicked", self.go_to_level)
-            buttons.append(self.item.button)
+    def _generate_grid(self):
+        row_count = int(math.ceil(
+            float(len(self._DISPLAYED_SCREENS)) / self._col_count)
+        )
 
-        # Fill the tabs with the current information
-        self.update_intro()
+        table = Gtk.Table(row_count, self._col_count, homogeneous=True,
+                          hexpand=True, vexpand=True)
+        table.props.margin = 0
 
-        # Create table
-        num_rows = len(self.names) / self.number_of_columns
-        if len(self.names) % self.number_of_columns != 0:  # Odd number of elements
-            num_rows += 1
-        self.table = Gtk.Table(num_rows, self.number_of_columns,
-                               True, hexpand=True, vexpand=True)
-        self.table.props.margin = 0
+        for idx, screen in enumerate(self._DISPLAYED_SCREENS):
+            row = idx / 2
+            col = idx % 2
 
-        # Attach to table
-        index = 0
-        row = 0
-        while index < len(self.names):
-            for j in range(0, self.number_of_columns):
-                if index < len(self.names):
-                    self.table.attach(buttons[index], j, j + 1, row, row + 1,
-                                      Gtk.AttachOptions.FILL | Gtk.AttachOptions.EXPAND,
-                                      Gtk.AttachOptions.FILL, 0, 0)
-                    if row % 2:
-                        buttons[index].get_style_context().add_class('appgrid_grey')
-                    else:
-                        buttons[index].get_style_context().add_class('appgrid_white')
-                    index += 1
-                else:
-                    break
-            row += 1
+            screen.create_menu_button(self._change_screen_cb)
 
-        # for scroll bar
-        self.scrolledwindow = ScrolledWindow(wide_scrollbar=True, vexpand=True,
-                                             hexpand=True)
-        self.scrolledwindow.get_style_context().add_class("app-grid")
-        self.scrolledwindow.add_with_viewport(self.table)
-
-    # This is to update the introduction text, so that if the settings are
-    # modified and then we go back to the intro screen, the latest information
-    # is shown
-    def update_intro(self):
-        for x in range(len(self.custom_info)):
-
-            if self.names[x] == 'Wifi':
-                text = ''
-                if common.has_internet:
-                    text = 'Connected'
-                else:
-                    text = 'Not connected'
-                self.labels[x].set_text(text)
-
-            elif self.names[x] == 'Account':
-                text = get_user_unsudoed()
-                self.labels[x].set_text(text)
-
-            elif self.names[x] == 'Display':
-                continue
-
+            if row % 2:
+                style_class = 'appgrid_grey'
             else:
-                self.labels[x].set_text(get_setting(self.custom_info[x]))
+                style_class = 'appgrid_white'
 
-    # When clicking next in the default intro screen - takes you to the last
-    # level you visited
-    def on_next(self, widget=None, arg2=None):
+            screen.menu_button.button.get_style_context().add_class(style_class)
 
-        self.state_to_widget(self.win.last_level_visited)(self.win)
-        self.win.last_level_visited = self.win.state
-        # Do not do win.show_all() as will stop the combotextbox in
-        # set_keyboard being hidden properly
+            screen.refresh_menu_button()
 
-    # On clicking a level button on default intro screen
-    def go_to_level(self, widget):
+            table.attach(screen.menu_button.button,
+                         col, col + 1, row, row + 1,
+                         Gtk.AttachOptions.FILL | Gtk.AttachOptions.EXPAND,
+                         Gtk.AttachOptions.FILL, 0, 0)
 
-        # Update current state
-        self.win.state = widget.state
-        # Record this level so we can go back to it
-        self.win.last_level_visited = self.win.state
 
-        # Call next state
+        scrolled_window = ScrolledWindow(wide_scrollbar=True, vexpand=True,
+                                         hexpand=True)
+        scrolled_window.get_style_context().add_class("app-grid")
+        scrolled_window.add_with_viewport(table)
+
+        return scrolled_window
+
+    def update_intro(self):
+        """
+        This is to update the introduction text, so that if the settings are
+        modified and then we go back to the intro screen, the latest information
+        is shown
+        """
+
+        for screen in self._DISPLAYED_SCREENS:
+            screen.refresh_menu_button()
+
+
+    def _change_screen_cb(self, screen, screen_name):
+        self.go_to_screen(screen_name)
+
+
+    def go_to_screen(self, screen_name):
+        self.win.state = screen_name
+        self.win.last_level_visited = screen_name
+
         self.win.clear_win()
-        self.state_to_widget(self.win.state)(self.win)
 
-    # On clicking a level button on default intro screen
-    def go_to_level_given_state(self, state):
+        try:
+            screen = SCREENS[screen_name]
+        except KeyError:
+            msg = "State {} not recognised".format(screen_name)
+            raise UnknownScreenError(msg)
 
-        # Remove element in the dynamic box
-        self.win.clear_win()
+        screen.screen_widget(self.win)
 
-        # Update current state
-        self.win.state = state
-        # Record this level so we can go back to it
-        self.win.last_level_visited = self.win.state
-
-        # Call next state
-        self.state_to_widget(self.win.state)(self.win)
-
-        # Refresh window
-        self.win.show_all()
-
-    def state_to_widget(self, x):
-        return {
-            0: choose_keyboard_screen,
-            1: SetMouse,
-            2: SetAudio,
-            3: SetDisplay,
-            4: SetWifi,
-            5: SetOverclock,
-            6: SetAccount,
-            7: SetAppearance,
-            8: SetFont,
-            9: SetAdvanced,
-            10: SetAbout,
-            11: SetNotifications,
-            12: NoInternet,
-            13: SetProxy,
-            14: FirstBootSetWallpaper
-        }[x]
+    def go_to_screen_number(self, screen_number):
+        screen = SCREENS.get_screen_from_number(screen_number)
+        screen.screen_widget(self.win)

--- a/kano_settings/main_window.py
+++ b/kano_settings/main_window.py
@@ -1,0 +1,126 @@
+# main_window
+#
+# Copyright (C) 2015 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+#
+# Main window class
+#
+
+import os
+from gi.repository import Gtk
+
+from kano.network import is_internet
+from kano.gtk3.apply_styles import apply_styling_to_screen, \
+    apply_common_to_screen
+from kano.gtk3.application_window import ApplicationWindow
+from kano.gtk3.kano_combobox import KanoComboBox
+from kano.gtk3.scrolled_window import ScrolledWindow
+from kano.gtk3.top_bar import TopBar
+from kano.gtk3.kano_dialog import KanoDialog
+from kano_profile.tracker import track_data
+
+import kano_settings.common as common
+from kano_settings.home_screen import HomeScreen
+from kano_settings.system.audio import is_HDMI
+from kano_settings.config_file import get_setting
+from kano_settings.system.display import get_status
+
+
+class MainWindow(ApplicationWindow):
+    state = 0
+    last_level_visited = 0
+    width = 680
+    height = 405
+    CSS_PATH = os.path.join(common.css_dir, 'style.css')
+
+    def __init__(self, screen_number=None, screen_name=None):
+        # Check for internet, if screen is 12 means no internet
+        if screen_number == 12 or screen_name == 'no-internet':
+            common.has_internet = False
+        else:
+            common.has_internet = is_internet()
+
+        # Set combobox styling to the screen
+        # Is done here so we don't attach the styling multiple times when
+        # switching screens
+        apply_styling_to_screen(self.CSS_PATH)
+        apply_common_to_screen()
+        KanoComboBox.apply_styling_to_screen()
+        ScrolledWindow.apply_styling_to_screen(wide=True)
+
+        # Set window
+        ApplicationWindow.__init__(self, "Settings", self.width, self.height)
+        self.set_decorated(True)
+        self.top_bar = TopBar("Settings")
+        self.top_bar.set_close_callback(self.close_window)
+        self.prev_handler = None
+        self.set_titlebar(self.top_bar)
+        self.set_icon_name("kano-settings")
+        self.connect("delete-event", Gtk.main_quit)
+        # In case we are called from kano-world-launcher, terminate splash
+        os.system('kano-stop-splash')
+        # Init to Home Screen
+        HomeScreen(self, screen_number=screen_number, screen_name=screen_name)
+
+    def clear_win(self):
+        self.remove_main_widget()
+
+    def go_to_home(self, widget=None, event=None):
+        self.clear_win()
+        HomeScreen(self)
+
+    def change_prev_callback(self, callback):
+        # first time, no event attached
+        self.remove_prev_callback()
+        self.prev_handler = self.top_bar.prev_button.connect(
+            "button-release-event", callback
+        )
+
+    def remove_prev_callback(self):
+        if self.prev_handler:
+            self.top_bar.prev_button.disconnect(self.prev_handler)
+            self.prev_handler = None
+
+    def _trigger_tracking_event(self):
+        """ Generate a tracker event with some hardware settings.
+
+            This will send a track_date event called 'user-settings'
+            with the audio setting, parental lock level and display
+            configuration.
+        """
+
+        track_data('user-settings', {
+            'audio': 'hdmi' if is_HDMI() else 'analog',
+            'parental-lock-level': get_setting('Parental-level'),
+            'display': get_status()
+        })
+
+    # On closing window, will alert if any of the listed booleans are True
+    def close_window(self, button, event):
+        if common.need_reboot:
+            kdialog = KanoDialog(
+                "Reboot?",
+                "Your Kano needs to reboot for changes to apply",
+                [
+                    {
+                        'label': "LATER",
+                        'color': 'grey',
+                        'return_value': False
+                    },
+                    {
+                        'label': "REBOOT NOW",
+                        'color': 'orange',
+                        'return_value': True
+                    }
+                ],
+                parent_window=self.get_toplevel()
+            )
+
+            kdialog.set_action_background("grey")
+            do_reboot_now = kdialog.run()
+            if do_reboot_now:
+                os.system("sudo reboot")
+
+        self._trigger_tracking_event()
+
+        Gtk.main_quit()

--- a/kano_settings/screens.py
+++ b/kano_settings/screens.py
@@ -1,0 +1,120 @@
+# screens.py
+#
+# Copyright (C) 2015 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+#
+# Structures to hold the screens
+#
+
+from collections import OrderedDict
+
+from kano.utils import get_user_unsudoed
+
+import kano_settings.common as common
+from kano_settings.config_file import get_setting
+from kano_settings.components.menu_button import Menu_button
+
+from kano_settings.set_keyboard import choose_keyboard_screen
+from kano_settings.set_mouse import SetMouse
+from kano_settings.set_notifications import SetNotifications
+from kano_settings.set_font import SetFont
+from kano_settings.set_audio import SetAudio
+from kano_settings.set_display import SetDisplay
+from kano_settings.set_wifi import SetWifi, SetProxy
+from kano_settings.no_internet_screen import NoInternet
+from kano_settings.set_overclock import SetOverclock
+from kano_settings.set_account import SetAccount
+from kano_settings.set_about import SetAbout
+from kano_settings.set_advanced import SetAdvanced
+from kano_settings.set_appearance import SetAppearance
+from kano_settings.set_wallpaper import FirstBootSetWallpaper
+
+
+class Screen(object):
+    """
+    NB: screen_no is here for legacy reasons - remove as soon as support is
+        withdrawn.
+    """
+
+    def __init__(self, name, label, screen_widget,
+                 screen_no=None, on_home_screen=True,
+                 setting_param=None):
+        self.name = name
+        self._label = label
+        self.screen_widget = screen_widget
+        self.screen_no = screen_no
+        self.on_home_screen = on_home_screen
+        self.menu_button = None
+        self._setting_param = setting_param
+
+    def create_menu_button(self, cb):
+        self.menu_button = button = Menu_button(self._label, '')
+        button.button.state = self.screen_no
+        button.button.connect('clicked', cb, self.name)
+
+    def refresh_menu_button(self):
+        description = ''
+
+        if self._setting_param:
+            description = get_setting(self._setting_param)
+        else:
+            if self.name == 'wifi':
+                if common.has_internet:
+                    description = 'Connected'
+                else:
+                    description = 'Not connected'
+
+            elif self.name == 'account':
+                description = get_user_unsudoed()
+
+            elif self.name == 'display':
+                return
+
+        self.menu_button.description.set_text(description)
+
+
+class ScreenCollection(OrderedDict):
+
+    def __init__(self, screens):
+        super(ScreenCollection, self).__init__()
+
+        for screen in screens:
+            self[screen.name] = screen
+
+    def get_screen_from_number(self, number):
+        for screen in self.itervalues():
+            if screen.screen_no == number:
+                return screen
+
+    def get_screens_on_home(self):
+        displayed_screens = []
+
+        for screen in self.itervalues():
+            if screen.on_home_screen:
+                displayed_screens.append(screen)
+
+        return displayed_screens
+
+
+SCREENS = ScreenCollection([
+    Screen('keyboard', 'Keyboard', choose_keyboard_screen, screen_no=0,
+           setting_param='Keyboard-country-human'),
+    Screen('mouse', 'Mouse', SetMouse, screen_no=1, setting_param='Mouse'),
+    Screen('audio', 'Audio', SetAudio, screen_no=2, setting_param='Audio'),
+    Screen('display', 'Display', SetDisplay, screen_no=3),
+    Screen('wifi', 'Wifi', SetWifi, screen_no=4),
+    Screen('overclocking', 'Overclocking', SetOverclock, screen_no=5,
+           setting_param='Overclocking'),
+    Screen('account', 'Account', SetAccount, screen_no=6),
+    Screen('appearance', 'Appearance', SetAppearance, screen_no=7,
+           setting_param='Wallpaper'),
+    Screen('font', 'Font', SetFont, screen_no=8, setting_param='Font'),
+    Screen('advanced', 'Advanced', SetAdvanced, screen_no=9),
+    Screen('about', 'About', SetAbout, screen_no=10),
+    Screen('notifications', 'Notifications', SetNotifications, screen_no=11),
+    Screen('no-internet', 'No-internet', NoInternet, screen_no=12,
+           on_home_screen=False),
+    Screen('proxy', 'proxy', SetProxy, screen_no=13, on_home_screen=False),
+    Screen('first-boot-set-wallpaper', 'first-boot-set-wallpaper',
+           FirstBootSetWallpaper, screen_no=14, on_home_screen=False)
+])


### PR DESCRIPTION
 - Moves the management of screen icons into a separate file
 - Reimagines the home screen code structure
 - Splits the main window class from the executable
 - Allows launching screens from the CLI using either the screen name or the (to be deprecated) screen number.
 - Installs the i18n libraries

I'm not quite satisfied with the `ScreenCollection` class - we need:
 - Elements to be ordered
 - Elements accessible by name
 - Elements accessibly by index (although this will be deprecated at some point)

cc @convolu @pazdera @carolineclark Thoughts? Comments?