### PR TITLE
Changes to WiFi GUI

### DIFF
--- a/bin/kano-wifi-gui
+++ b/bin/kano-wifi-gui
@@ -74,6 +74,7 @@ class KanoWifiGui(ApplicationWindow):
         self.set_titlebar(self.top_bar)
         self.top_bar.set_close_callback(Gtk.main_quit)
         self.set_icon_name("kano-settings")
+        self.set_keep_above(True)
 
         # Only go through this stage if you don't have internet
         # check if a wifi dongle is plugged in

--- a/kano_wifi_gui/NetworkScreen.py
+++ b/kano_wifi_gui/NetworkScreen.py
@@ -120,7 +120,11 @@ class NetworkScreen(Gtk.Box):
             label = Gtk.Label(network['essid'])
             box.pack_start(label, False, False, 0)
 
-            if network['essid'] == network_connection[0]:
+            # If the network name of the button matches the last attempted
+            # connection, and we're connected to the internet, then
+            # put a tick next to the name.
+            if network['essid'] == network_connection[0] and \
+                    network_connection[3]:
                 tick = tick_icon()
                 box.pack_start(tick, False, False, 0)
 

--- a/kano_wifi_gui/PasswordScreen.py
+++ b/kano_wifi_gui/PasswordScreen.py
@@ -122,8 +122,7 @@ class PasswordScreen(Gtk.Box):
         logger.debug('Connecting to {}'.format(ssid))
 
         # disable the buttons
-        self.connect_btn.set_sensitive(False)
-        self.win.top_bar.prev_button.set_sensitive(False)
+        self._disable_widgets()
         self.connect_btn.start_spinner()
 
         # start thread
@@ -159,8 +158,7 @@ class PasswordScreen(Gtk.Box):
 
     def _thread_finish(self, success):
         self.connect_btn.stop_spinner()
-        self.connect_btn.set_sensitive(True)
-        self.win.top_bar.prev_button.set_sensitive(True)
+        self._enable_widgets()
 
         if success:
             kdialog = KanoDialog(
@@ -173,3 +171,15 @@ class PasswordScreen(Gtk.Box):
 
         else:
             self.wrong_password_screen()
+
+    def _disable_widgets(self):
+        self.connect_btn.set_sensitive(False)
+        self.win.top_bar.prev_button.set_sensitive(False)
+        self.password_entry.set_sensitive(False)
+        self.show_password.set_sensitive(False)
+
+    def _enable_widgets(self):
+        self.connect_btn.set_sensitive(True)
+        self.win.top_bar.prev_button.set_sensitive(True)
+        self.password_entry.set_sensitive(True)
+        self.show_password.set_sensitive(True)

--- a/media/kano-connect/CSS/kano_wifi_gui.css
+++ b/media/kano-connect/CSS/kano_wifi_gui.css
@@ -47,6 +47,11 @@ GtkScrolledWindow.border {
     font: Bariol bold 13;
 }
 
+.show_password GtkLabel:insensitive {
+    color: @kano_grey;
+    background: transparent;
+}
+
 .grey {
     color: #dddddd;
     background: #dddddd;


### PR DESCRIPTION
 - Disables checkbutton and password entry
 - WiFi window should always stay on top
 - GUI should only appear to be connected to a network if it has internet.

https://github.com/KanoComputing/peldins/issues/1864
https://github.com/KanoComputing/peldins/issues/1863
https://github.com/KanoComputing/peldins/issues/1861
https://github.com/KanoComputing/peldins/issues/1862