### PR TITLE
Allow kano-connect to proceed even if Ethernet cable

### DIFF
--- a/bin/kano-connect
+++ b/bin/kano-connect
@@ -43,6 +43,10 @@ from kano.network import IWList, is_device, is_gateway, connect, disconnect, is_
 # filename to keep our process semaphore
 pidfile = '/var/run/kano-connect.pid'
 
+# If this file is present, kano-connect will try to connect
+# even if the Ethernet cable is plugged in.
+file_multihomed=/var/opt/kano-connect/multihomed
+
 def remove_pid(filename):
     try:
         os.unlink(filename)
@@ -84,7 +88,7 @@ if __name__ == '__main__':
         sys.exit(1)
 
     # Check for ethernet cable
-    if is_ethernet_plugged():
+    if is_ethernet_plugged() and not os.path.isfile(file_multihomed):
         logger.info('ethernet cable is plugged in, exiting')
         sys.exit(0)
 

--- a/debian/kano-connect.postrm
+++ b/debian/kano-connect.postrm
@@ -19,6 +19,8 @@ case "$1" in
 
         fi
 
+        # remove the control file to force kano-connect into multihomed
+        rm -rf /var/opt/kano-connect/
 
         ;;
 esac


### PR DESCRIPTION
 * When the ethernet cable is plugged in, kano-connect will still
   try to associate wirelessly if a control file is found (force multihomed mode)