### PR TITLE
Fixing get_username when Kit boots for the first time

### DIFF
--- a/kano_settings/system/get_username.py
+++ b/kano_settings/system/get_username.py
@@ -28,18 +28,18 @@ grp_field_id = {
     }
 
 def get_real_users():
-    users = grp.getgrnam('kanousers')[grp_field_id['gr_mem']]
-    user_data = [pwd.getpwnam(u) for u in users]
-    return user_data
-
+    try:
+        users = grp.getgrnam('kanousers')[grp_field_id['gr_mem']]
+        user_data = [pwd.getpwnam(u) for u in users]
+        return user_data
+    except:
+        return None
 
 def get_first_username():
     real_users = get_real_users()
+    if real_users:
+        real_users.sort(key=lambda x: x[pwd_field_id['pw_uid']])
+        if len(real_users) > 0:
+            return real_users[0][pwd_field_id['pw_name']]
 
-    real_users.sort(key=lambda x: x[pwd_field_id['pw_uid']])
-
-    if len(real_users) > 0:
-        return real_users[0][pwd_field_id['pw_name']]
-    else:
-        return None
-
+    return None


### PR DESCRIPTION
When the kano kit boots for the first time, kano-init complains with `unable to resolve host kano`.
On the build logs there's an execption `KeyError: 'getgrnam(): name not found: kanousers'`.
This changeset controls this exception to return None, so the code proceeds correctly.

@Ealdwulf @alex5imon 
