### PR TITLE
Parental: Add function to retrieve parental level

### DIFF
--- a/kano_settings/system/advanced.py
+++ b/kano_settings/system/advanced.py
@@ -31,6 +31,7 @@ from kano.utils import read_file_contents, write_file_contents, \
 from kano.logging import logger
 from kano.network import set_dns, restore_dns_interfaces, \
     clear_dns_interfaces, refresh_resolvconf
+from kano_settings.config_file import get_setting
 
 password_file = "/etc/kano-parental-lock"
 hosts_file = '/etc/hosts'
@@ -52,6 +53,13 @@ def get_parental_enabled():
     enabled = os.path.exists(password_file)
     logger.debug('get_parental_enabled: {}'.format(enabled))
     return enabled
+
+
+def get_parental_level():
+    if not get_parental_enabled():
+        return 0
+
+    return get_setting('Parental-level') + 1
 
 
 def set_parental_enabled(setting, _password):


### PR DESCRIPTION
KanoComputing/peldins#1919
Although the parental level can be retrieved through `config_file`'s
`get_setting` function, this is intended for use solely within Kano
Settings (for the UI). Also, to get the correct setting, a combination
of `get_setting` and checking if the parental controls are enabled at
all is required to get the correct setting so add a function to allow
the setting to be retrieved by third parties.

@alex5imon It is much easier to add a function to do this rather
than rework how the value is handled internally to Settings and
configure the update scenarios for every user. If you would like
the function to behave differently then let me know.