### PR TITLE
Make kano-settings-onboot run before lightdm.

### DIFF
--- a/etc/init.d/kano-settings
+++ b/etc/init.d/kano-settings
@@ -4,8 +4,28 @@
 # Provides:         kano-settings
 # Required-Start:
 # Required-Stop:
+# X-Start-Before:   lightdm
 # Default-Start:    2
 # Default-Stop:
 ### END INIT INFO
 
-/usr/bin/kano-settings-onboot
+. /lib/lsb/init-functions
+
+case "$1" in
+    start)
+	log_action_begin_msg "Running kano-settings-onboot"
+	/usr/bin/kano-settings-onboot
+	log_action_end_msg $?
+	;;
+    stop)
+	;;
+    restart|reload|force-reload|status)
+        echo "Error: argument '$1' not supported" >&2
+        exit 3
+	;;
+    *)
+      echo "Usage: kano-settings [start|stop]" >&2
+      exit 3
+      ;;
+esac
+qsudo reboot


### PR DESCRIPTION
@alex5imon This PR foces kano-settings-onboot to run before lightdm 
It also adds some standard init boiler-plate which adds a message showing it running  in the same way as all the other scripts in init.d, and prevents it being called with 'stop'). 

However, it turns out that kano-settings-onboot takes about 15 seconds to run. Therefore maybe we don't want to run it before lightdm because doing so may prevent the desktop for 15 more seconds appearing in the case where we are not going to reboot. Thoughts @pazdera @skarbat @tombettany ?
