### PR TITLE
Split kano-settings-onboot

### DIFF
--- a/bin/kano-safeboot-mode
+++ b/bin/kano-safeboot-mode
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+# kano-settings-onboot
+#
+# Copyright (C) 2014, 2015 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+#
+# Configure HDMI settings on boot.
+#
+# Also calls code to set clock config, to avoid need to an extra reboot.
+import os
+import sys
+
+if __name__ == '__main__' and __package__ is None:
+    dir_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+    if dir_path != '/usr':
+        sys.path.insert(1, dir_path)
+
+from kano.utils import run_cmd, enforce_root
+from kano.logging import logger
+from kano_settings.boot_config import enforce_pi, is_safe_boot, safe_mode_backup_config
+from kano_settings.system.display import set_safeboot_mode
+
+logger.force_log_level('info')
+
+def safe_boot_requested():
+    """ Test whether the CTRL+ALT keys were pressed. """
+
+    # Start a board LED blink in the background for a few seconds
+    # so the user knows it's time to press Ctrl-Alt
+    _, _, _ = run_cmd("/usr/bin/kano-led &")
+
+    _, _, rv = run_cmd("kano-keys-pressed")
+    return rv == 10
+
+
+# main program
+enforce_pi()
+enforce_root('Need to be root!')
+
+
+# Reconfigure and reboot if the user requested safe mode
+# Or if the cable appears not to have been plugged in.
+if safe_boot_requested() and not is_safe_boot():
+    logger.warn("Safe boot requested")
+
+    # Backup the config file
+    safe_mode_backup_config()
+
+    set_safeboot_mode()
+
+    # Trigger a reboot
+    logger.sync()
+    run_cmd('reboot -f')
+    sys.exit()

--- a/bin/kano-safeboot-mode
+++ b/bin/kano-safeboot-mode
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# kano-settings-onboot
+# kano-safeboot-mode
 #
 # Copyright (C) 2014, 2015 Kano Computing Ltd.
 # License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2

--- a/bin/kano-settings-onboot
+++ b/bin/kano-settings-onboot
@@ -20,17 +20,15 @@ if __name__ == '__main__' and __package__ is None:
 from kano.utils import run_cmd, enforce_root
 from kano.logging import logger
 from kano_settings.system.display import get_status, get_model, set_hdmi_mode, \
-    get_edid, is_mode_fallback
+    get_edid, is_mode_fallback, set_safeboot_mode
 from kano_settings.boot_config import set_config_value, set_config_comment, \
-    get_config_comment, get_config_value, has_config_comment
+    get_config_comment, get_config_value, has_config_comment, \
+    enforce_pi, is_safe_boot, safe_mode_backup_config, safe_mode_restore_config
 from kano_settings.system.audio import is_HDMI, set_to_HDMI
 from kano_settings.system.overclock_chip_support import check_clock_config_matches_chip
 
 logger.force_log_level('info')
 
-tvservice_path = '/usr/bin/tvservice'
-config_txt_path = '/boot/config.txt'
-config_txt_backup_path = '/boot/config.txt.orig'
 
 screen_log_path = '/boot/screen.log'
 
@@ -41,12 +39,6 @@ overrides = {
 }
 
 
-def enforce_pi():
-    pi_detected = os.path.exists(tvservice_path) and \
-        os.path.exists(config_txt_path)
-    if not pi_detected:
-        logger.error('need to run on a Raspberry Pi')
-        sys.exit()
 
 
 def check_model_present(model):
@@ -144,12 +136,6 @@ def safe_boot_requested():
     return rv == 10
 
 
-def is_safe_boot():
-    """ Test whether the unit is booting in the safe mode already. """
-
-    return os.path.isfile(config_txt_backup_path)
-
-
 def get_screen_information():
     """ Retrieves the information about the current screen.
 
@@ -192,19 +178,9 @@ if safe_boot_requested() and not is_safe_boot() or is_mode_fallback():
     logger.warn("Safe boot requested")
 
     # Backup the config file
-    shutil.copy2(config_txt_path, config_txt_backup_path)
+    safe_mode_backup_config()
 
-    set_config_value("hdmi_force_hotplug", 1)
-    set_config_value("config_hdmi_boost", 4)
-
-    set_config_value("hdmi_group", 2)
-    set_config_value("hdmi_mode", 16)
-
-    set_config_value("disable_overscan", 1)
-    set_config_value("overscan_left", 0)
-    set_config_value("overscan_right", 0)
-    set_config_value("overscan_top", 0)
-    set_config_value("overscan_bottom", 0)
+    set_safeboot_mode()
 
     # Trigger a reboot
     reboot_now = True
@@ -221,7 +197,7 @@ if is_safe_boot():
     logger.info("In safe boot mode, restoring config.txt, skipping autoconfig")
     
     # Restore the config.txt file
-    shutil.move(config_txt_backup_path, config_txt_path)
+    safe_mode_restore_config()
 
     sys.exit()
 

--- a/bin/kano-settings-onboot
+++ b/bin/kano-settings-onboot
@@ -125,17 +125,6 @@ def compare_and_set_overscan():
         return True
 
 
-def safe_boot_requested():
-    """ Test whether the CTRL+ALT keys were pressed. """
-
-    # Start a board LED blink in the background for a few seconds
-    # so the user knows it's time to press Ctrl-Alt
-    _, _, _ = run_cmd("/usr/bin/kano-led &")
-
-    _, _, rv = run_cmd("kano-keys-pressed")
-    return rv == 10
-
-
 def get_screen_information():
     """ Retrieves the information about the current screen.
 
@@ -174,8 +163,8 @@ if check_clock_config_matches_chip():
 
 # Reconfigure and reboot if the user requested safe mode
 # Or if the cable appears not to have been plugged in.
-if safe_boot_requested() and not is_safe_boot() or is_mode_fallback():
-    logger.warn("Safe boot requested")
+if is_mode_fallback():
+    logger.warn("executing fallback boot")
 
     # Backup the config file
     safe_mode_backup_config()

--- a/debian/kano-settings.install
+++ b/debian/kano-settings.install
@@ -2,6 +2,7 @@ bin/kano-settings /usr/bin
 bin/kano-settings-cli /usr/bin
 bin/startmouse /usr/bin
 bin/kano-settings-onboot /usr/bin
+bin/kano-safeboot-mode /usr/bin
 bin/regenerate-ssh-keys /usr/bin
 bin/start-sentry-server /usr/bin
 

--- a/debian/kano-settings.postinst
+++ b/debian/kano-settings.postinst
@@ -46,6 +46,9 @@ case "$1" in
         # add kano-settings-onboot to startup
         update-rc.d kano-settings defaults
 
+        # add kano-safeboot-mode to startup
+        update-rc.d kano-safeboot defaults
+
         # add kano-bootup-sound to startup
         update-rc.d kano-bootup-sound defaults
 

--- a/etc/init.d/kano-safeboot
+++ b/etc/init.d/kano-safeboot
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+### BEGIN INIT INFO
+# Provides:         kano-safeboot
+# Required-Start:
+# Required-Stop:
+# X-Start-Before:   
+# Default-Start:    2
+# Default-Stop:
+### END INIT INFO
+
+. /lib/lsb/init-functions
+
+case "$1" in
+    start)
+	log_action_begin_msg "Checking for kano-safeboot-mode"
+	/usr/bin/kano-safeboot-mode
+	log_action_end_msg $?
+	;;
+    stop)
+	;;
+    restart|reload|force-reload|status)
+        echo "Error: argument '$1' not supported" >&2
+        exit 3
+	;;
+    *)
+      echo "Usage: kano-safeboot [start|stop]" >&2
+      exit 3
+      ;;
+esac
+

--- a/etc/init.d/kano-settings
+++ b/etc/init.d/kano-settings
@@ -28,4 +28,4 @@ case "$1" in
       exit 3
       ;;
 esac
-qsudo reboot
+

--- a/etc/init.d/kano-settings
+++ b/etc/init.d/kano-settings
@@ -4,8 +4,28 @@
 # Provides:         kano-settings
 # Required-Start:
 # Required-Stop:
+# X-Start-Before:   lightdm
 # Default-Start:    2
 # Default-Stop:
 ### END INIT INFO
 
-/usr/bin/kano-settings-onboot
+. /lib/lsb/init-functions
+
+case "$1" in
+    start)
+	log_action_begin_msg "Running kano-settings-onboot"
+	/usr/bin/kano-settings-onboot
+	log_action_end_msg $?
+	;;
+    stop)
+	;;
+    restart|reload|force-reload|status)
+        echo "Error: argument '$1' not supported" >&2
+        exit 3
+	;;
+    *)
+      echo "Usage: kano-settings [start|stop]" >&2
+      exit 3
+      ;;
+esac
+qsudo reboot

--- a/kano_settings/boot_config.py
+++ b/kano_settings/boot_config.py
@@ -161,6 +161,6 @@ def safe_mode_backup_config():
     shutil.copy2(boot_config_standard_path, boot_config_safemode_backup_path)
 
 
-def safe_mode_restore_Config():
+def safe_mode_restore_config():
     shutil.move(boot_config_safemode_backup_path, boot_config_standard_path)
 

--- a/kano_settings/boot_config.py
+++ b/kano_settings/boot_config.py
@@ -19,8 +19,7 @@ boot_config_standard_path = "/boot/config.txt"
 boot_config_pi1_backup_path = "/boot/config_pi1_backup.txt"
 boot_config_pi2_backup_path = "/boot/config_pi2_backup.txt"
 tvservice_path = '/usr/bin/tvservice'
-config_txt_path = '/boot/config.txt'
-config_txt_backup_path = '/boot/config.txt.orig'
+boot_config_safemode_backup_path = '/boot/config.txt.orig'
 
 
 class BootConfig:
@@ -151,15 +150,17 @@ def enforce_pi():
         logger.error('need to run on a Raspberry Pi')
         sys.exit()
 
+
 def is_safe_boot():
     """ Test whether the unit is booting in the safe mode already. """
 
-    return os.path.isfile(config_txt_backup_path)
+    return os.path.isfile(boot_config_safemode_backup_path)
+
 
 def safe_mode_backup_config():
-    shutil.copy2(config_txt_path, config_txt_backup_path)
+    shutil.copy2(boot_config_standard_path, boot_config_safemode_backup_path)
 
 
 def safe_mode_restore_Config():
-    shutil.move(config_txt_backup_path, config_txt_path)
+    shutil.move(boot_config_safemode_backup_path, boot_config_standard_path)
 

--- a/kano_settings/boot_config.py
+++ b/kano_settings/boot_config.py
@@ -10,12 +10,17 @@
 
 import re
 import os
+import sys
+import shutil
 from kano.utils import read_file_contents_as_lines, is_number
 from kano.logging import logger
 
 boot_config_standard_path = "/boot/config.txt"
 boot_config_pi1_backup_path = "/boot/config_pi1_backup.txt"
 boot_config_pi2_backup_path = "/boot/config_pi2_backup.txt"
+tvservice_path = '/usr/bin/tvservice'
+config_txt_path = '/boot/config.txt'
+config_txt_backup_path = '/boot/config.txt.orig'
 
 
 class BootConfig:
@@ -137,3 +142,24 @@ def get_config_comment(name, value):
 
 def has_config_comment(name):
     return real_config.has_comment(name)
+
+
+def enforce_pi():
+    pi_detected = os.path.exists(tvservice_path) and \
+        os.path.exists(boot_config_standard_path)
+    if not pi_detected:
+        logger.error('need to run on a Raspberry Pi')
+        sys.exit()
+
+def is_safe_boot():
+    """ Test whether the unit is booting in the safe mode already. """
+
+    return os.path.isfile(config_txt_backup_path)
+
+def safe_mode_backup_config():
+    shutil.copy2(config_txt_path, config_txt_backup_path)
+
+
+def safe_mode_restore_Config():
+    shutil.move(config_txt_backup_path, config_txt_path)
+

--- a/kano_settings/system/display.py
+++ b/kano_settings/system/display.py
@@ -122,6 +122,22 @@ def set_hdmi_mode(group=None, mode=None):
 
     set_config_value("hdmi_mode", mode)
 
+def set_safeboot_mode():
+    logger.warn("Safe boot requested")
+
+    set_config_value("hdmi_force_hotplug", 1)
+    set_config_value("config_hdmi_boost", 4)
+
+    set_config_value("hdmi_group", 2)
+    set_config_value("hdmi_mode", 16)
+
+    set_config_value("disable_overscan", 1)
+    set_config_value("overscan_left", 0)
+    set_config_value("overscan_right", 0)
+    set_config_value("overscan_top", 0)
+    set_config_value("overscan_bottom", 0)
+
+
 
 def get_status():
     status = dict()


### PR DESCRIPTION
This PR splits kano-settings-onboot into two parts so one part can be run before lightdm while the remaining part can be run after but take more time.
