### PR TITLE
Added missing wifi cache cleanup on disconnect

### DIFF
--- a/kano_wifi_gui/NetworkScreen.py
+++ b/kano_wifi_gui/NetworkScreen.py
@@ -25,7 +25,13 @@ from kano.network import (connect, is_connected, KwifiCache, disconnect,
 
 
 def disconnect_dialog(wiface='wlan0', win=None):
+    '''
+    Disconnect and empty the cached credentials, to avoid an automatic reconnection
+    '''
     disconnect(wiface)
+    wificache = KwifiCache()
+    wificache.empty()
+
     kdialog = KanoDialog(
         # Text from the content team.
         "Disconnect complete - you're now offline.",


### PR DESCRIPTION
 * The wireless cached credentials were not being removed on disconnect,
   so the desktop network plugin would quickly reconnect back to wireless.