### PR TITLE
Parental: Fix setting DNS for Medium and High settings

### DIFF
--- a/kano_settings/system/advanced.py
+++ b/kano_settings/system/advanced.py
@@ -605,10 +605,10 @@ def set_parental_level(level_setting):
     if 'ultimate' in enabled:
         set_ultimate_parental('ultimate' in enabled)
     else:
+        set_ultimate_parental(False)
         set_chromium_parental('chromium' in enabled)
         set_dns_parental('dns' in enabled)
         set_everyone_cookies('cookies' in enabled)
-        set_ultimate_parental(False)
 
     # Blacklist setup
     blacklist, whitelist = read_listed_sites()


### PR DESCRIPTION
When setting the parental setting to Medium or High, the ultimate
parental setting code would revert the DNS servers to Google's, not
OpenDNS's. Rectify this by running the parental DNS configuration after
the ultimate parental code so that they don't get overwritten.

@FMog Built on `scratch` for you to test.

@carolineclark @convolu Could you review.

cc @alex5imon 