### PR TITLE
Add dependencies on $local_fs, which is necessary for logging to work.

### DIFF
--- a/etc/init.d/kano-safeboot
+++ b/etc/init.d/kano-safeboot
@@ -2,7 +2,7 @@
 
 ### BEGIN INIT INFO
 # Provides:         kano-safeboot
-# Required-Start:
+# Required-Start:   $local_fs
 # Required-Stop:
 # X-Start-Before:   
 # Default-Start:    2

--- a/etc/init.d/kano-settings
+++ b/etc/init.d/kano-settings
@@ -2,7 +2,7 @@
 
 ### BEGIN INIT INFO
 # Provides:         kano-settings
-# Required-Start:
+# Required-Start:   $local_fs
 # Required-Stop:
 # X-Start-Before:   lightdm
 # Default-Start:    2


### PR DESCRIPTION
This PR adds a dependency to kano-safeboot-mode and kano-settings-onboot to wait for the filesystem to be remounted read/write. For safeboot mode this only affects logging, possibly without this  kano-settings-onboot woudl break if it was run too early, although I'm not sure if /boot actually gets mounted readonly at the start of time or not.
It is possible that there are other missing dependencies For example if we depend on some device then we should also ensure that it has been initialised. However I can't see any obvious missing ones...
@skarbat @pazdera @tombettany 