### PR TITLE
Fix font settings panel not to invoke init flow

### DIFF
--- a/kano_settings/system/font.py
+++ b/kano_settings/system/font.py
@@ -33,8 +33,7 @@ def change_font_size(configuration):
     pattern = font.format("[0-9]+")
     replace = font.format(size)
 
-    # Apply changes
+    # Apply changes: For jessie, this is automatically reloaded by lxsession 
     file_replace(config_file, pattern, replace)
-    # Reload lxsession
-    os.system("lxsession -r")
+
     logger.debug('set_font / change_font_size: selected_button:{}'.format(configuration))


### PR DESCRIPTION
This PR removes a call to `lxsession -r` which is no longer needed in the version of
LXDE on jessie (and causes problems). This is still needed on wheezy, so can't
be merged on master. Note this may mean we should add a dependency for a later version
of lxsession.
However kano-settions doesn't currently have a dependency on lxssession, should it be added?
@pazdera @tombettany @radujipa 
