### PR TITLE
Fixed random exceptions on particular displays

### DIFF
--- a/kano_settings/system/display.py
+++ b/kano_settings/system/display.py
@@ -298,7 +298,9 @@ def parse_edid(edid_txt):
 
         # model name
         elif 'monitor name is' in l:
-            edid['model'] = l.split('monitor name is')[1].strip()
+            # Some displays return garbage, on old firmwares it can also be random.
+            model=l.split('monitor name is')[1].strip()
+            edid['model'] = model.decode('ascii', 'ignore')
 
         # preferred
         elif 'found preferred' in l:


### PR DESCRIPTION
 * Some displays may return garbage data when querying EDID info
   on the model name data field. Fixed by sanitizing the returned string.

cc @Ealdwulf @alex5imon 