### PR TITLE
Parental: Prevent hanging when starting sentry server

### DIFF
--- a/kano_settings/system/advanced.py
+++ b/kano_settings/system/advanced.py
@@ -430,7 +430,10 @@ def redirect_traffic_to_localhost():
 
 
 def launch_sentry_server(filename):
-    subprocess.Popen(["sentry -c {}".format(filename)], shell=True)
+    subprocess.Popen(
+        ["sentry -c {}".format(filename)], shell=True,
+        stdin=subprocess.PIPE, stdout=subprocess.PIPE
+    )
 
 
 def kill_server():


### PR DESCRIPTION
KanoComputing/peldins#2175
When attempting to connect to WiFi, with ultimate parental controls
enabled and the sentry server not running, the GUI can hang despite
having fully established a connection. This is because launching the
sentry server was done in a way that it was waiting on stdin. Resolve
this by explicitly declaring the stdin source.

Supersedes https://github.com/KanoComputing/kano-settings/pull/330

@convolu @Ealdwulf Can we try this again?