### PR TITLE
Limit reboots

### DIFF
--- a/bin/kano-checked-reboot
+++ b/bin/kano-checked-reboot
@@ -10,7 +10,7 @@
 # Usage: kano-checked-reboot <why> <cmd> <cmd_args...>
 
 # The first argument is written to a randomly named sentinel file.
-# The remaining arguemnts are executed as a command.
+# The remaining arguments are executed as a command.
 
 import os
 import sys
@@ -26,7 +26,7 @@ files = os.listdir(REBOOT_DIR)
 
 if len(files) > REBOOT_MAX:
     from kano.logging import logger
-    logger.error("More than 3 reboots!")
+    logger.error("More than {} reboots!".format(REBOOT_MAX))
     exit(1)
 
 # any extra args are passed to

--- a/bin/kano-checked-reboot
+++ b/bin/kano-checked-reboot
@@ -55,4 +55,4 @@ os.close(dirfd)
 
 os.system('sync')
 
-os.system(' '.join(cmd_plus_args))
+os.system(cmd_plus_args)

--- a/bin/kano-checked-reboot
+++ b/bin/kano-checked-reboot
@@ -1,0 +1,58 @@
+#!/usr/bin/python
+# kano-check-reboot
+#
+# Copyright (C) 2014, 2015 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+#
+# Wrapper for reboot. Will refuse to reboot more than REBOOT_MAX times
+# between calls to kano-reboot-clear
+
+# Usage: kano-checked-reboot <why> <cmd> <cmd_args...>
+
+# The first argument is written to a randomly named sentinel file.
+# The remaining arguemnts are executed as a command.
+
+import os
+import sys
+import tempfile
+
+REBOOT_DIR = '/boot/kano_reboots'
+REBOOT_MAX = 3
+
+# Ensure reboot directory exists
+os.system('mkdir -p ' + REBOOT_DIR)
+
+files = os.listdir(REBOOT_DIR)
+
+if len(files) > REBOOT_MAX:
+    from kano.logging import logger
+    logger.error("More than 3 reboots!")
+    exit(1)
+
+# any extra args are passed to
+cmd_plus_args = ' '.join(sys.argv[2:])
+
+why = sys.argv[1]
+
+if len(sys.argv) < 3:
+    from kano.logging import logger
+    logger.error("No reboot command passed!")
+    exit(1)
+
+
+# Add a file to count another reboot
+(fd, name) = tempfile.mkstemp(dir=REBOOT_DIR)
+
+# Ensure that the file is written to disk, and appears in
+# the correct directory, before the reboot.
+os.write(fd, why)
+os.fsync(fd)
+os.close(fd)
+
+dirfd = os.open(REBOOT_DIR, os.O_DIRECTORY)
+os.fsync(dirfd)
+os.close(dirfd)
+
+os.system('sync')
+
+os.system(' '.join(cmd_plus_args))

--- a/bin/kano-safeboot-mode
+++ b/bin/kano-safeboot-mode
@@ -50,6 +50,5 @@ if safe_boot_requested() and not is_safe_boot():
 
     # Trigger a reboot
     logger.sync()
-    run_cmd('sync')
-    run_cmd('systemctl reboot --force')
+    run_cmd('kano-checked-reboot safeboot systemctl reboot --force')
     sys.exit()

--- a/bin/kano-settings-onboot
+++ b/bin/kano-settings-onboot
@@ -196,8 +196,7 @@ if reboot_now:
         logger.debug("rebooting")
     else:
         logger.sync()
-        run_cmd('sync')
-        run_cmd('systemctl reboot --force')
+        run_cmd('kano-checked-reboot reboot_now systemctl reboot --force')
     sys.exit()
 
 
@@ -266,5 +265,4 @@ if changes:
         logger.debug("rebooting due to config changes")
     else:
         logger.sync()
-        run_cmd('sync')
-        run_cmd('systemctl reboot --force')
+        run_cmd('kano-checked-reboot changes systemctl reboot --force')

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kano-settings (2.2-3) unstable; urgency=low
+
+  * Add kano-checked-reboot
+
+ -- Team Kano <dev@kano.me>  Thu, 07 Jan 2016 19:18:00 +0000
+
 kano-settings (2.2-2) unstable; urgency=low
 
   * Changes on Parental Control

--- a/debian/kano-settings.install
+++ b/debian/kano-settings.install
@@ -5,6 +5,7 @@ bin/kano-settings-onboot /usr/bin
 bin/kano-safeboot-mode /usr/bin
 bin/regenerate-ssh-keys /usr/bin
 bin/start-sentry-server /usr/bin
+bin/kano-checked-reboot /usr/bin
 
 kano_settings/* /usr/lib/python2.7/dist-packages/kano_settings
 media/kano-settings/* /usr/share/kano-settings/media

--- a/debian/kano-settings.postinst
+++ b/debian/kano-settings.postinst
@@ -55,6 +55,9 @@ case "$1" in
         # add kano-bootup-sound to startup
         update-rc.d kano-bootup-sound defaults
 
+        # add kano-reboot-clear to startup
+        update-rc.d kano-reboot-clear defaults
+
 	# Check for default hostname and set to name of first user
 	python -c "from kano_settings.system.advanced import set_hostname_postinst; set_hostname_postinst()"
 

--- a/etc/init.d/kano-reboot-clear
+++ b/etc/init.d/kano-reboot-clear
@@ -25,9 +25,7 @@ case "$1" in
         # Display a welcome message to the bootup terminal
 	log_action_begin_msg "Running kano-reboot-clear"
 	(
-	    echo "kano-reboot-clear starting" >/dev/tty1
 	    sleep 333 ;	rm -rf /boot/kano_reboots	
-	    echo "kano-reboot-clear done" >/dev/tty1
 	) & 
 	log_action_end_msg $?
 	;;

--- a/etc/init.d/kano-reboot-clear
+++ b/etc/init.d/kano-reboot-clear
@@ -1,4 +1,11 @@
 #!/bin/sh
+# 
+# kano-reboot-clear
+#
+# Copyright (C) 2016 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+#
+
 
 ### BEGIN INIT INFO
 # Provides:         kano-reboot-clear

--- a/etc/init.d/kano-reboot-clear
+++ b/etc/init.d/kano-reboot-clear
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+### BEGIN INIT INFO
+# Provides:         kano-reboot-clear
+# Required-Start:   $local_fs $all kano-settings kano-safeboot-mode
+# Required-Stop:
+# X-Start-Before:   
+# Default-Start:    2 3 4 5
+# Default-Stop:
+### END INIT INFO
+
+. /lib/lsb/init-functions
+
+case "$1" in
+    start)
+        # Display a welcome message to the bootup terminal
+	log_action_begin_msg "Running kano-reboot-clear"
+	echo "kano-reboot-clear starting" >/dev/tty1
+	sleep 333
+	echo "kano-reboot-clear starting" >/dev/tty1 
+	rm -rf /boot/kano_reboots	
+	log_action_end_msg $?
+	;;
+    stop)
+	;;
+    restart|reload|force-reload|status)
+        echo "Error: argument '$1' not supported" >&2
+        exit 3
+	;;
+    *)
+      echo "Usage: kano-reboot-clear [start|stop]" >&2
+      exit 3
+      ;;
+esac
+

--- a/etc/init.d/kano-reboot-clear
+++ b/etc/init.d/kano-reboot-clear
@@ -9,6 +9,15 @@
 # Default-Stop:
 ### END INIT INFO
 
+
+# This file clears reboot sentinels, which are used by kano-checked-reboot
+# to avoid indefinite rebooting.
+# The idea of this script is to clear the sentinels only when it is reasonly clear that we have
+# bootted stably.
+#
+# Frustratingly systemd ignores the $all dependency, so we additionally depend on all
+# scripts we know contain reboot commands and then wait for an additional period to be safe.
+
 . /lib/lsb/init-functions
 
 case "$1" in

--- a/etc/init.d/kano-reboot-clear
+++ b/etc/init.d/kano-reboot-clear
@@ -2,7 +2,7 @@
 
 ### BEGIN INIT INFO
 # Provides:         kano-reboot-clear
-# Required-Start:   $local_fs $all kano-settings kano-safeboot-mode
+# Required-Start:   $local_fs $all kano-settings kano-safeboot
 # Required-Stop:
 # X-Start-Before:   
 # Default-Start:    2 3 4 5

--- a/etc/init.d/kano-reboot-clear
+++ b/etc/init.d/kano-reboot-clear
@@ -15,10 +15,11 @@ case "$1" in
     start)
         # Display a welcome message to the bootup terminal
 	log_action_begin_msg "Running kano-reboot-clear"
-	echo "kano-reboot-clear starting" >/dev/tty1
-	sleep 333
-	echo "kano-reboot-clear starting" >/dev/tty1 
-	rm -rf /boot/kano_reboots	
+	(
+	    echo "kano-reboot-clear starting" >/dev/tty1
+	    sleep 333 ;	rm -rf /boot/kano_reboots	
+	    echo "kano-reboot-clear done" >/dev/tty1
+	) & 
 	log_action_end_msg $?
 	;;
     stop)


### PR DESCRIPTION
@alex5imon @convolu 
This PR prevents an unlimited number of reboots. It contains:
* A wrapper script for systemctl reboot. This builds up sentinel files per reboot and refuses to work
if there are too many. It also does sync itself, so I have removed that from call locations.
* An init script which clears the sentinels, when it appears that the system has settled.

It appears to be unavoiable that we have a timeout-based heuristc to see if teh system has settled. 
I have made this 5 minutes. That means that if someone changes there settings quickly, it won't have an effect due to refusing a reboot. Any opinions on the correct period? @FMog, I guess you are most likely to be bitten by this! 

I have set the max number of reboots at 3 (because I know kano-init reset can cause this scenario). Anyone think a different figure should apply, please comment.

This is for https://github.com/KanoComputing/peldins/issues/2186

