### PR TITLE
Parental: Ensure parental setting gets updated

### DIFF
--- a/kano_settings/parental_config.py
+++ b/kano_settings/parental_config.py
@@ -17,7 +17,7 @@ from kano.gtk3.buttons import OrangeButton
 from kano.gtk3.kano_dialog import KanoDialog
 from kano_profile.tracker import track_data
 
-from kano_settings.config_file import get_setting, set_setting
+from kano_settings.config_file import get_setting
 from system.advanced import write_whitelisted_sites, write_blacklisted_sites, \
     read_listed_sites, set_parental_level, authenticate_parental_password
 
@@ -107,7 +107,6 @@ class ParentalConfig(Template):
 
         level = self.parental_level.get_value()
         set_parental_level(level)
-        set_setting('Parental-level', level)
 
         # track which parental control level people use
         track_data("parental-control-level-changed", {

--- a/kano_settings/system/advanced.py
+++ b/kano_settings/system/advanced.py
@@ -27,7 +27,7 @@ from kano.utils import read_file_contents, write_file_contents, \
     get_user_unsudoed, chown_path
 from kano.network import set_dns, restore_dns_interfaces, \
     clear_dns_interfaces, refresh_resolvconf
-from kano_settings.config_file import get_setting
+from kano_settings.config_file import get_setting, set_setting
 
 password_file = "/etc/kano-parental-lock"
 hosts_file = '/etc/hosts'
@@ -586,6 +586,8 @@ def write_blacklisted_sites(blacklist):
 
 
 def set_parental_level(level_setting):
+    set_setting('Parental-level', max(level_setting, 1))
+
     # NB, we pass -1 to disable all
     feature_levels = [
         # Low


### PR DESCRIPTION
If the ultimate parental control has been set and disabled without
updating the config file, then the script that starts the Sentry server
reports that parental control is enabled and thus network settings don't
get properly set. Resolve this by writing the change to the config file
every time some change occurs to the parental setting.

cc @convolu @Ealdwulf 