### PR TITLE
Config locking

### DIFF
--- a/bin/kano-safeboot-mode
+++ b/bin/kano-safeboot-mode
@@ -17,7 +17,8 @@ if __name__ == '__main__' and __package__ is None:
 
 from kano.utils import run_cmd, enforce_root
 from kano.logging import logger
-from kano_settings.boot_config import enforce_pi, is_safe_boot, safe_mode_backup_config
+from kano_settings.boot_config import enforce_pi, is_safe_boot, \
+    safe_mode_backup_config, end_config_transaction
 from kano_settings.system.display import set_safeboot_mode
 
 logger.force_log_level('info')
@@ -47,6 +48,8 @@ if safe_boot_requested() and not is_safe_boot():
     safe_mode_backup_config()
 
     set_safeboot_mode()
+
+    end_config_transaction()
 
     # Trigger a reboot
     logger.sync()

--- a/bin/kano-settings-onboot
+++ b/bin/kano-settings-onboot
@@ -24,7 +24,8 @@ from kano_settings.system.display import get_status, get_model, set_hdmi_mode, \
 from kano_settings.boot_config import set_config_value, set_config_comment, \
     get_config_comment, get_config_value, has_config_comment, \
     enforce_pi, is_safe_boot, safe_mode_backup_config, \
-    safe_mode_restore_config, remove_noobs_defaults, set_dry_run
+    safe_mode_restore_config, remove_noobs_defaults, set_dry_run, \
+    end_config_transaction
 from kano_settings.system.audio import is_HDMI, set_to_HDMI
 from kano_settings.system.overclock_chip_support import check_clock_config_matches_chip
 
@@ -192,6 +193,7 @@ if is_mode_fallback():
 
 # If we need to set anything to do with config.txt, reboot
 if reboot_now:
+    end_config_transaction()
     if dry_run:
         logger.debug("rebooting")
     else:
@@ -205,6 +207,7 @@ if is_safe_boot():
 
     # Restore the config.txt file
     safe_mode_restore_config()
+    end_config_transaction()
 
     sys.exit()
 
@@ -260,6 +263,7 @@ changes = compare_and_set_mode() or compare_and_set_full_range() or \
 if changes:
     # write comment to config
     set_config_comment('kano_screen_used', model)
+    end_config_transaction()
     # reboot
     if dry_run:
         logger.debug("rebooting due to config changes")

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kano-settings (2.2-4) unstable; urgency=low
+
+  * Change config API to use a transactional approach
+
+ -- Team Kano <dev@kano.me>  Fri, 15 Jan 2016 11:00:00 +0000
+
 kano-settings (2.2-3) unstable; urgency=low
 
   * Add kano-checked-reboot

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Build-Depends: debhelper (>= 9), build-essential, pkg-config, libgtk2.0-dev,
 Package: kano-settings
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, kano-connect (= ${binary:Version}),
-         python, python-gi, dante-client, kano-toolset (>= 2.3.0-1),
+         python, python-gi, dante-client, kano-toolset (>= 2.3.0-4),
          kano-profile (>= 2.1-1), gir1.2-gtk-3.0, libkdesk-dev, sentry (>= 0.5-0),
          python-bs4, python-pycountry, kano-i18n, libnss-mdns, avahi-daemon,
          kano-content

--- a/kano_settings/boot_config.py
+++ b/kano_settings/boot_config.py
@@ -7,11 +7,14 @@
 #
 # Functions controlling reading and writing to /boot/config.txt
 #
+# NOTE this api has changed to use a transactional approach.
+# See documentation at the start of ConfigTransaction() 
 
 import re
 import os
 import sys
 import shutil
+import tempfile
 from kano.utils import read_file_contents_as_lines
 from kano.utils import is_number, open_locked
 from kano.logging import logger
@@ -21,22 +24,29 @@ boot_config_pi1_backup_path = "/boot/config_pi1_backup.txt"
 boot_config_pi2_backup_path = "/boot/config_pi2_backup.txt"
 tvservice_path = '/usr/bin/tvservice'
 boot_config_safemode_backup_path = '/boot/config.txt.orig'
+lock_dir = '/run/lock'
+
+dry_run = False
+lock_timeout = 5
+
+def set_dry_run():
+    """
+    Set dry run on all config files.
+    """
+    global dry_run
+    dry_run = True
 
 
 class BootConfig:
-    def __init__(self, path=boot_config_standard_path):
+    # Class which knows how to make individual modifications to a config file.
+    # Shoudl only be used within this module to allow locking.
+    
+    def __init__(self, path=boot_config_standard_path, read_only=True):
         self.path = path
-        self.dry_run = False
+        self.read_only = read_only
 
     def exists(self):
         return os.path.exists(self.path)
-
-    def set_dry_run(self):
-        """
-        Set dry run mode. If set, no actual changes will be written to
-        disk; instead more logging will happen.
-        """
-        self.dry_run = True
 
     def ensure_exists(self):
         if not self.exists():
@@ -54,22 +64,18 @@ class BootConfig:
         Remove the config entries added by Noobs,
         by removing all the lines after and including
         noobs' sentinel
-        
-        """
-        if self.dry_run:
-            logger.debug("Removing Noobs default values")
-            return
 
+        """
         lines = read_file_contents_as_lines(self.path)
         noobs_line = "# NOOBS Auto-generated Settings:"
         if noobs_line in lines:
             with open_locked(self.path, "w") as boot_config_file:
-                
+
                 for line in lines:
                     if line == noobs_line:
                         break
-                    
-                    boot_config_file.write(line+ "\n")
+
+                    boot_config_file.write(line + "\n")
 
                 # flush changes to disk
                 boot_config_file.flush()
@@ -77,7 +83,7 @@ class BootConfig:
 
             return True
         return False
-        
+
 
     def set_value(self, name, value=None):
         # if the value argument is None, the option will be commented out
@@ -88,10 +94,6 @@ class BootConfig:
         logger.info('writing value to {} {} {}'.format(self.path, name, value))
 
         option_re = r'^\s*#?\s*' + str(name) + r'=(.*)'
-
-        if self.dry_run:
-            logger.debug("Setting config value {} in {} to {}".format(name, self.path, value))
-            return
 
         with open_locked(self.path, "w") as boot_config_file:
             was_found = False
@@ -140,10 +142,6 @@ class BootConfig:
         comment_str_full = '### {}: {}'.format(name, value)
         comment_str_name = '### {}'.format(name)
 
-        if self.dry_run:
-            logger.debug("setting comment {} in {} to {}".format(name, self.path, value))
-            return
-
         with open_locked(self.path, "w") as boot_config_file:
             boot_config_file.write(comment_str_full + '\n')
 
@@ -178,41 +176,166 @@ class BootConfig:
         return False
 
 
-real_config = BootConfig()
+class ConfigTransaction:
+    def __init__(self, path):
+        # This class represents a transaction on the config files.
+        #  It ensures that only one process can execute a transaction at a time.
+        #  A transaction is defined as starting when any read or write operation is
+        #  performed, eg get get_config_value, and ending when either close()
+        #  or abort() is called.
+        #
+        # To make the transaction atomic, when any write operation is called,
+        # a temporary copy of config.txt is made. This is then used for all read or write
+        # opertions until the transaction is ended.
+        #  
+        #  It has three states:
+        #  * 0 : IDLE
+        #  * 1 : Locked
+        #  * 2 : Writable
+
+        # The attributes 'lock' and 'temp_config'
+        # and 'temp_path' have different values depending on state - 
+        # see valid_state().
+
+        # To initialise a transaction, we do two things:
+        #  * Obtain a lockfile in a tempfs directory
+        #    (so even if we are killed, it will not persist across boots)
+        #  * make a new file with a unique name in the same directory as the
+        #    config file we are going to modify
+        self.path = path
+        self.base = os.path.basename(path)
+        self.dir = os.path.dirname(path)
+
+        self.lockpath = os.path.join(lock_dir,
+                                     'kano_config_'+self.base+'.lock')
+
+        self.state = None
+        self.set_state_idle()
+
+    def valid_state(self):
+        # validity condition for states
+        if self.state == 0:
+            return (self.lock is None and
+                    isinstance(self.temp_config, BootConfig) and
+                    self.temp_config.path == self.path and
+                    self.temp_path is None
+                    )
+        if self.state == 1:
+            return (isinstance(self.lock, open_locked) and
+                    self.temp_config.path == self.path and
+                    self.temp_path is None
+                    )
+        if self.state == 2:
+            return (isinstance(self.lock, open_locked) and
+                    self.temp_config.path == self.temp_path and
+                    self.temp_path is not None
+                    )
+
+    def set_state_idle(self):
+        if self.state is None:
+            self.temp_config = BootConfig(self.path)
+            self.temp_path = None
+            self.lock = None
+            self.state = 0
+
+        if self.state == 2:
+            # For pure read operations, set up access to config
+            self.temp_config = BootConfig(self.path)
+            self.state = 1
+            self.temp_path = None
+
+        if self.state == 1:
+            self.lock.close()
+            self.lock = None
+            self.state = 0
+
+    def raise_state_to_locked(self):
+        if self.state == 0:
+            self.state = 1
+            self.lock = open_locked(self.lockpath, "w", timeout=lock_timeout)
+
+    def set_state_writable(self):
+
+        if self.state == 0:
+            self.raise_state_to_locked()
+
+        if self.state == 1:
+
+            temp = tempfile.NamedTemporaryFile(mode="w",
+                                               delete=False,
+                                               prefix="config_tmp_",
+                                               dir=self.dir)
+            self.temp_path = temp.name
+            logger.info("Enable modifications in  config transaction: {}".format(self.temp_path))
+            temp.close()
+            shutil.copyfile(self.path, self.temp_path)
+
+            # create temporary
+            self.temp_config = BootConfig(self.temp_path)
+
+        self.state = 2
+
+    def set_config_value(self, name, value=None):
+        self.set_state_writable()
+        self.temp_config.set_value(name, value)
+
+    def get_config_value(self, name):
+        self.raise_state_to_locked()
+        return self.temp_config.get_value(name)
+
+    def set_config_comment(self, name, value):
+        self.set_state_writable()
+        self.temp_config.set_comment(name, value)
+
+    def get_config_comment(self, name, value):
+        self.raise_state_to_locked()
+        return self.temp_config.get_comment(name, value)
+
+    def has_config_comment(self, name):
+        self.raise_state_to_locked()
+        return self.temp_config.has_comment(name)
+
+    def remove_noobs_defaults(self):
+        self.set_state_writable()
+        return self.temp_config.remove_noobs_defaults()
+
+    def copy_to(self, dest):
+        # Copy to a file. Note that if we have modified in this transaction,
+        # include the changes.
+        self.raise_state_to_locked()
+        if self.temp_path:
+            path = self.temp_path
+        else:
+            path = self.path
+        shutil.copy2(path, boot_config_safemode_backup_path)
+
+    def copy_from(self, src):
+        self.set_state_writable()
+        shutil.copy2(boot_config_safemode_backup_path, self.temp_path)
+
+    def close(self):
+        if self.state == 2:
+            if dry_run:
+                logger.info("dry run config transaction can be found in {}".format(self.temp_path))
+            else:
+                logger.info("closing config transaction")
+                shutil.move(self.temp_path, self.path)
+                # sync
+                dirfd = os.open(self.dir, os.O_DIRECTORY)
+                os.fsync(dirfd)
+                os.close(dirfd)
+                os.system('sync')
+
+        else:
+            logger.warn("closing config transaction with no edits")
+        self.set_state_idle()
+
+    def abort(self):
+        os.remove(self.temp_path)
+        self.set_state_idle()
+
 pi1_backup_config = BootConfig(boot_config_pi1_backup_path)
 pi2_backup_config = BootConfig(boot_config_pi2_backup_path)
-
-def set_dry_run():
-    """
-    Set dry run on all config files.
-    """
-    real_config.set_dry_run()
-    pi1_backup_config.set_dry_run()
-    pi2_backup_config.set_dry_run()
-    
-
-
-def set_config_value(name, value=None):
-    real_config.set_value(name, value)
-
-
-def get_config_value(name):
-    return real_config.get_value(name)
-
-
-def set_config_comment(name, value):
-    real_config.set_comment(name, value)
-
-
-def get_config_comment(name, value):
-    return real_config.get_comment(name, value)
-
-
-def has_config_comment(name):
-    return real_config.has_comment(name)
-
-def remove_noobs_defaults():
-    return real_config.remove_noobs_defaults()
 
 
 def enforce_pi():
@@ -223,6 +346,46 @@ def enforce_pi():
         sys.exit()
 
 
+_transaction = None
+
+def _trans():
+    global _transaction
+    if not _transaction:
+        _transaction = ConfigTransaction(boot_config_standard_path)
+    return _transaction
+
+def set_config_value(name, value=None):
+    _trans().set_config_value(name, value)
+
+
+def get_config_value(name):
+    return _trans().get_config_value(name)
+
+
+def set_config_comment(name, value):
+    _trans().set_config_comment(name, value)
+
+
+def get_config_comment(name, value):
+    return _trans().get_config_comment(name, value)
+
+
+def has_config_comment(name):
+    return _trans().has_config_comment(name)
+
+
+def remove_noobs_defaults():
+    return _trans().remove_noobs_defaults()
+
+
+def end_config_transaction():
+    _trans().close()
+
+
+def end_config_transaction_no_writeback():
+    _trans().abort()
+
+
 def is_safe_boot():
     """ Test whether the unit is booting in the safe mode already. """
 
@@ -230,8 +393,8 @@ def is_safe_boot():
 
 
 def safe_mode_backup_config():
-    shutil.copy2(boot_config_standard_path, boot_config_safemode_backup_path)
+    _trans().copy_to(boot_config_safemode_backup_path)
 
 
 def safe_mode_restore_config():
-    shutil.move(boot_config_safemode_backup_path, boot_config_standard_path)
+    _trans().copy_from(boot_config_safemode_backup_path)

--- a/kano_settings/default.py
+++ b/kano_settings/default.py
@@ -33,6 +33,7 @@ def set_default_config():
     set_config_value('hdmi_pixel_encoding', 2)
     set_config_value('hdmi_group', None)
     set_config_value('hdmi_mode', None)
+    set_config_value('display_rotate', 0)
     set_config_comment('kano_screen_used', 'xxx')
 
     # resetting overclocking settings

--- a/kano_settings/default.py
+++ b/kano_settings/default.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+
+# default.py
+#
+# Copyright (C) 2014,2015 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+#
+# Function to restore factory default config.
+
+from kano_settings.system.audio import set_to_HDMI
+from kano_settings.boot_config import set_config_value, set_config_comment
+from kano_settings.boot_config import end_config_transaction
+from kano_settings.system.overclock import set_default_overclock_values
+from kano_settings.system.keyboard_config import set_keyboard
+from kano.utils import is_model_2_b
+
+
+def set_default_config():
+    # restore factory defaults
+
+    # setting the audio to analogue
+    set_to_HDMI(False)
+
+    set_config_value('hdmi_ignore_edid_audio', 1)
+    set_config_value('hdmi_drive', None)
+
+    # resetting HDMI settings
+    set_config_value('disable_overscan', 1)
+    set_config_value('overscan_left', 0)
+    set_config_value('overscan_right', 0)
+    set_config_value('overscan_top', 0)
+    set_config_value('overscan_bottom', 0)
+    set_config_value('hdmi_pixel_encoding', 2)
+    set_config_value('hdmi_group', None)
+    set_config_value('hdmi_mode', None)
+    set_config_comment('kano_screen_used', 'xxx')
+
+    # resetting overclocking settings
+    set_default_overclock_values(is_model_2_b())
+
+    # set the keyboard to default
+    set_keyboard('en_US', 'generic')
+
+    end_config_transaction()

--- a/kano_settings/set_display.py
+++ b/kano_settings/set_display.py
@@ -14,7 +14,7 @@ from kano_settings.components.heading import Heading
 from kano_profile.tracker import track_data
 
 import kano_settings.common as common
-from kano_settings.boot_config import set_config_comment, get_config_value
+from kano_settings.boot_config import set_config_comment, get_config_value, end_config_transaction
 from kano_settings.system.display import get_model, get_status, list_supported_modes, set_hdmi_mode, read_hdmi_mode, \
     find_matching_mode, get_overscan_status, write_overscan_values, set_overscan_status, launch_pipe, set_flip
 
@@ -109,6 +109,8 @@ class SetDisplay(Template):
                     "mode": parse_mode
                 })
 
+                end_config_transaction()
+
                 common.need_reboot = True
 
             self.win.go_to_home()
@@ -145,6 +147,7 @@ class SetDisplay(Template):
     def flip(self, button):
         set_flip(button.get_active())
         self.kano_button.set_sensitive(True)
+        end_config_transaction()
         common.need_reboot = True
 
 class OverscanTemplate(Gtk.Box):
@@ -183,9 +186,11 @@ class OverscanTemplate(Gtk.Box):
 
     def apply_changes(self, button, event):
         # Apply changes
+        set_config_comment('kano_screen_used', get_model())
+        # NB, write_overscan_values ends the transaction
         write_overscan_values(self.overscan_values)
         self.original_overscan = self.overscan_values
-        set_config_comment('kano_screen_used', get_model())
+
 
         # Tell user to reboot to see changes
         common.need_reboot = True

--- a/kano_settings/set_overclock.py
+++ b/kano_settings/set_overclock.py
@@ -9,7 +9,7 @@
 from gi.repository import Gdk
 from kano_settings.templates import RadioButtonTemplate
 import kano_settings.common as common
-from kano_settings.boot_config import get_config_value
+from kano_settings.boot_config import get_config_value, end_config_transaction
 from kano_settings.system.overclock import CLOCK_MODES, change_overclock_value, is_dangerous_overclock_value
 from kano.utils import is_model_2_b
 from kano.gtk3.kano_dialog import KanoDialog
@@ -18,7 +18,6 @@ from kano.gtk3.kano_dialog import KanoDialog
 class SetOverclock(RadioButtonTemplate):
     selected_button = 0
     initial_button = 0
-    boot_config_file = "/boot/config.txt"
 
     def __init__(self, win):
         self.is_pi2 = is_model_2_b()
@@ -99,6 +98,7 @@ class SetOverclock(RadioButtonTemplate):
                 change_overclock_value(config, self.is_pi2)
 
                 # Tell user to reboot to see changes
+                end_config_transaction()
                 common.need_reboot = True
 
                 self.win.go_to_home()

--- a/kano_settings/system/audio.py
+++ b/kano_settings/system/audio.py
@@ -9,7 +9,7 @@
 
 
 from kano_settings.config_file import get_setting, set_setting, file_replace
-from kano_settings.boot_config import set_config_value
+from kano_settings.boot_config import set_config_value, end_config_transaction
 from kano.utils import run_cmd
 from kano.logging import logger
 
@@ -55,6 +55,8 @@ def set_to_HDMI(HDMI):
         set_config_value("hdmi_ignore_edid_audio", 1)
         set_config_value("hdmi_drive", None)
         config = "Analogue"
+
+    end_config_transaction()
 
     # Set audio path in amixer
     o, e, rc = run_cmd(amixer_cmd)

--- a/kano_settings/system/display.py
+++ b/kano_settings/system/display.py
@@ -12,7 +12,7 @@ import os
 import re
 import subprocess
 import time
-from kano_settings.boot_config import set_config_value, get_config_value
+from kano_settings.boot_config import set_config_value, get_config_value, end_config_transaction
 from kano.utils import run_cmd, delete_file
 from kano.logging import logger
 
@@ -22,6 +22,8 @@ xrefresh_path = '/usr/bin/xrefresh'
 
 
 def switch_display_safe_mode():
+    # NB this function appears to be unused
+
     # Finds the first available display resolution that is safe
     # and switches to this mode immediately
     safe_resolution = '1024x768'
@@ -238,13 +240,16 @@ def write_overscan_values(overscan_values):
     set_config_value('overscan_bottom', overscan_values['bottom'])
     set_config_value('overscan_left', overscan_values['left'])
     set_config_value('overscan_right', overscan_values['right'])
+    end_config_transaction()
 
 
 def is_overscan():
+    # This completes a transaction to avoid kano-video holding the lock
     top = get_config_value('overscan_top')
     bottom = get_config_value('overscan_bottom')
     left = get_config_value('overscan_left')
     right = get_config_value('overscan_right')
+    end_config_transaction()
     return (top or bottom or left or right)
 
 

--- a/tests/boot_config/__init__.py
+++ b/tests/boot_config/__init__.py
@@ -1,0 +1,9 @@
+#
+# __init__.py
+#
+# Copyright (C) 2016 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+#
+
+__author__ = 'Kano Computing Ltd.'
+__email__ = 'dev@kano.me'

--- a/tests/boot_config/test_config.py
+++ b/tests/boot_config/test_config.py
@@ -1,0 +1,305 @@
+#
+# test_config.py
+#
+# Copyright (C) 2016 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+#
+# This module tests boot_config.py
+#
+
+
+import unittest
+import sys
+import os
+from kano.utils import is_number
+
+sys.path.insert(1, os.path.abspath(
+    os.path.join(os.path.dirname(__file__), '..')))
+
+import kano_settings.system.locale as locale
+import kano.utils as utils
+
+from tests.tools import test_print, mock_file
+import re
+import shutil
+import copy
+import random
+
+print '''
+***************************
+******* Test Config *******
+***************************
+
+'''
+
+random.seed(12345)  # test should be deterministic
+
+dummy_config_data = """
+
+### foo: bar
+hdmi_ignore_edid_audio=1
+# junk
+"""
+config_path = '/boot/config.txt'
+
+
+class config_vals:
+    # Class to hold config values for comparison
+    def __init__(self, values, comment_values, comments):
+        self.values = values   # for lines of the form foo=bar
+        self.comment_values = comment_values  # for lines of the form ### foo: bar
+        self.comments = comments  # All other lines
+
+    def copy(self):
+        return config_vals(copy.copy(self.values),
+                           copy.copy(self.comment_values),
+                           copy.copy(self.comments))
+
+
+def read_config(path=config_path):
+    # read a config file for comparison, into a config_vals object
+
+    lines = open(path, "r").readlines()
+    values = {}
+    comment_values = {}
+    comments = []
+    commentRe = re.compile('### ([^:]+): (.*)')
+    valRe = re.compile('([^=]+)=(.*)')
+
+    for x in lines:
+        m = commentRe.match(x)
+        if m:
+            comment_values[m.group(1)] = m.group(2)
+            continue
+        m = valRe.match(x)
+        if m:
+            values[m.group(1)] = m.group(2)
+            if is_number(m.group(2)):
+                values[m.group(1)] = int(m.group(2))
+            continue
+        comments.append(x)
+    return config_vals(values, comment_values, comments)
+
+
+def compare(a, b):
+    if set(a.comments) != set(b.comments):
+        print "comment difference", a.comments, b.comments
+        return False
+
+    if set(a.comment_values.keys()) != set(b.comment_values.keys()):
+        print " comment set different", a.comment_values.keys(), b.comment_values.keys()
+        return False
+
+    for k in a.comment_values.keys():
+        if a.comment_values[k] != b.comment_values[k]:
+            print "comment value difference", k, a.comment_values[k], b.comment_values[k]
+            return False
+
+    if set(a.values.keys()) != set(b.values.keys()):
+        print " value set different", a.values.keys(), b.values.keys()
+        return False
+
+    for k in a.values.keys():
+        if a.values[k] != b.values[k]:
+            print "value difference", k, a.values[k], b.values[k]
+            return False
+    return True
+
+
+class configSetTest(unittest.TestCase):
+    # The main test.
+    # We want to test  the following: 
+    #    All read methods read correct value
+    #    all read methods cause lock
+    #    all write methods cause lock
+    #    all write methods don't write back until writeback
+    #    all writes are copied back after writeback
+    #    locking is blocking
+    #    All methods maintain the state invariants defined by valid_state()
+
+    # To do this, we maintain three sets of configs:
+    # 'current' (the current value of /boot/config.txt
+    # 'written' (The value that will be written back at the end of the transaction)
+    # 'backup' (The value of the safe mode backup config)
+
+    def test_set_config(self):
+        from kano_settings import boot_config
+
+        def choose_key(present, data):
+            # Choose either  a key of a dictionary, or a key not present
+            if present:
+                key = random.choice(data.keys())
+            else:
+                # choose a key that is not present
+                key = str(random.randint(0, 10000000))
+                while key in data.keys():
+                    key = str(random.randint(0, 10000000))
+            return key
+
+
+        def is_locked():
+            # Check whether the lock is effective. Return true if the lock is held
+            
+            import os
+            py = os.path.join(os.path.dirname(__file__), 'test_lock.py')
+            return os.system('python '+py) != 0
+
+        def test_read(configs):
+            # Test all read methods
+            # Check the result of the read against the 'written' config set.
+            
+            which = random.randint(0, 3)
+            present = random.randint(0, 1) == 1
+            if which == 0:
+                # test get_config_value
+
+                key = choose_key(present, configs['written'].values)
+
+                # test case when key is present and not present
+
+                v = boot_config.get_config_value(key)
+                print "testing get_config_value({}) => {}".format(key, v)
+
+                if present:
+                    self.assertTrue(v == configs['written'].values[key])
+                else:
+                    self.assertTrue(v == 0)
+
+            elif which == 1:
+                # test get_config_comment
+
+                # test case when key is present and not present
+                key = choose_key(present, configs['written'].comment_values)
+                if present:
+                    correct = random.randint(0, 1)
+                    value = configs['written'].comment_values[key]
+                    if not correct:
+                        value = value + '_wrong'
+                else:
+                    correct = False
+                    value = str(random.randint(0, 10))
+
+                v = boot_config.get_config_comment(key, value)
+                print "testing get_config_comment({},{}) => {}".format(key, value, v)
+
+                # get_config comment
+                self.assertTrue(v == (present and correct))
+
+            elif which == 2:
+                # test has_config_comment
+
+                # test case when key is present and not present
+                key = choose_key(present, configs['written'].comment_values)
+
+                v = boot_config.has_config_comment(key)
+                print "testing has_config_comment({}) => {}".format(key, v)
+
+                self.assertTrue(v == present)
+
+            elif which == 3:
+                # test copy_to
+
+                print "testing safe_mode_config_backup"
+                boot_config.safe_mode_backup_config()
+
+                configs['backup'] = read_config(boot_config.boot_config_safemode_backup_path)
+
+                self.assertTrue(compare(configs['backup'], configs['written']))
+
+            # after a read, state should be at least locked.
+            self.assertTrue(boot_config._trans().state >= 1)
+
+            # after a read, config should be unmodified
+            after_read = read_config()
+
+            self.assertTrue(compare(configs['current'], after_read))
+            self.assertTrue(is_locked())
+
+        def test_write(configs):
+            which = random.randint(0, 3)
+            present = random.randint(0, 1) == 1
+
+            before_write = configs['current'].copy()
+
+            if which == 0:
+                # test set_config_value
+
+                key = choose_key(present, configs['current'].values)
+                value = random.randint(0, 1000)
+
+                print "testing set_config_value({},{})".format(key, value)
+                boot_config.set_config_value(key, value)
+                configs['written'].values[key] = value
+
+            elif which == 1:
+                # test set_config_comment
+                key = choose_key(present, configs['current'].comment_values)
+                value = str(random.randint(0, 1000))
+
+                print "testing set_config_comment({},{})".format(key, value)
+                boot_config.set_config_comment(key, value)
+                configs['written'].comment_values[key] = value
+
+            elif which == 2:
+                # test restore_backup
+
+                print "testing safe_mode_restore_backup"
+                boot_config.safe_mode_restore_config()
+                configs['written'] = read_config(boot_config._trans().temp_path)
+
+                self.assertTrue(compare(configs['backup'], configs['written']))
+
+            elif which == 3:
+                # test remove_noobs_defaults
+                boot_config.remove_noobs_defaults()
+                print "testing remove_noobs_defaults"
+                # FIXME this is not properly tested yet
+
+            after_write = read_config()
+
+            self.assertTrue(compare(before_write, after_write))
+            self.assertTrue(boot_config._trans().state == 2)
+            self.assertTrue(is_locked())
+
+        def test_close(configs):
+            boot_config.end_config_transaction()
+            configs['current'] = read_config()
+
+            print "testing close"
+
+            # all written items should now be present
+            self.assertTrue(compare(configs['current'], configs['written']))
+            self.assertTrue(boot_config._trans().state == 0)
+            self.assertTrue(not is_locked())
+
+
+        with mock_file(config_path, dummy_config_data):
+
+            self.assertTrue(not is_locked())
+
+            orig = read_config()
+
+            self.assertTrue(boot_config._trans().valid_state())
+            self.assertTrue(boot_config._trans().state == 0)
+
+            numtests = random.randint(0, 1000)
+
+            configs = {}
+            configs['current'] = orig
+            configs['written'] = orig.copy()
+
+            for trial in range(numtests):
+                rwc = random.randint(0, 2)
+
+                if rwc == 0:
+                    test_read(configs)
+                elif rwc == 1:
+                    test_write(configs)
+                else:
+                    test_close(configs)
+
+                # after each operation, state shuold be valid
+                self.assertTrue(boot_config._trans().valid_state())
+
+            # Sanity check - did we actually test anything?
+            os.system('cat /boot/config.txt')

--- a/tests/boot_config/test_lock.py
+++ b/tests/boot_config/test_lock.py
@@ -1,0 +1,22 @@
+#
+# test_config.py
+#
+# Copyright (C) 2016 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+#
+# This script returns a value depending on whether the config.txt lock is available.
+# 0 for no, 1 for yes
+
+from kano_settings import boot_config
+from kano.utils.file_operations import TimeoutException
+import sys
+
+boot_config.lock_timeout = 0.2
+try:
+    boot_config.has_config_comment("foo")
+    print "Lock was unlocked"
+
+    sys.exit(0)
+except TimeoutException:
+    print "Lock was locked"
+    sys.exit(1)

--- a/tests/test.py
+++ b/tests/test.py
@@ -19,7 +19,8 @@ sys.path.insert(1, os.path.abspath(
 
 SUITE = unittest.TestSuite()
 TESTS = [
-    'tests.i18n.test_locale'
+#    'tests.i18n.test_locale',
+    'tests.boot_config.test_config'
 ]
 
 for test in TESTS:

--- a/tests/test.py
+++ b/tests/test.py
@@ -19,7 +19,7 @@ sys.path.insert(1, os.path.abspath(
 
 SUITE = unittest.TestSuite()
 TESTS = [
-#    'tests.i18n.test_locale',
+    'tests.i18n.test_locale',
     'tests.boot_config.test_config'
 ]
 


### PR DESCRIPTION
This PR changes the settings API to be transactional, and changes the settings tools to use it.

All changes are applied to temporary file in `/boot`, which is moved into place at the end. This will hopefullly prevent the 'empty config file' problem.

All the functions which write  to `/boot/config.txt` will no longer take effect until a call to end_config_transaction(). This includes things like `safe_mode_restore_config`as well as the more obvious ones.  Note that read functions as well as write functions start a transaction. During a transaction, a lock is held so any access by other processes will wait (for up to 5 seconds) and then time out. This wait is in case the boot scripts happen to run at the same time.


This is a bit a bit complicated so APIs used externally to  the kano-settings repo  do an entire transaction. Fortunately there are not many of these. So while some scripts use `set_config_value` and the new `end_config_transaction`, these are ones that live in the kano-settings repo (eg kano-settings-onboot). For this purpose I've moved the config setting in kano-init into a new API function kano_settings.default.set_default_config(), and made the one API used in kano-init-flow (`write_overscan values`) terminate its transaction, and similarly `is_overscan()` which is used by kano-video also terminates its transaction.

@skarbat @pazdera @convolu @tombettany 