### PR TITLE
Don't complain when config reads are not followed by `end_transaction()`

### DIFF
--- a/kano_settings/boot_config.py
+++ b/kano_settings/boot_config.py
@@ -342,7 +342,11 @@ class ConfigTransaction:
         # for program exit: check if the transaction has been left open,
         # close it, and raise an error.
 
-        if self.state > 0:
+        # NB, we don't complain if only reads have happened. Ideally
+        # we might want to close read transactions to avoid locking for
+        # long periods, but it's not a safety issue so leave it for now.
+
+        if self.state > 1:
             self.close()
             raise OpenTransactionError()
 


### PR DESCRIPTION
We have a lot of places where we do `get_config_value()` and don't follow it by and `end_config_transaction()`, These are safe, so we don't need to raise an exception when this happens.

Ideally we should close these too to avoid taking the lock for more than the shortest possible time, but it's not a safety issue so I prefer to leave it for now.
