### PR TITLE
Correct corrupt config

### DIFF
--- a/bin/kano-settings-onboot
+++ b/bin/kano-settings-onboot
@@ -162,6 +162,7 @@ enforce_root('Need to be root!')
 
 # Check for corrupt config file
 if check_corrupt_config():
+    logger.error("Found corrupt config file! Restoring default.")
     reboot_now = True
 
 # Gather and log data about the current screen

--- a/bin/kano-settings-onboot
+++ b/bin/kano-settings-onboot
@@ -25,7 +25,7 @@ from kano_settings.boot_config import set_config_value, set_config_comment, \
     get_config_comment, get_config_value, has_config_comment, \
     enforce_pi, is_safe_boot, safe_mode_backup_config, \
     safe_mode_restore_config, remove_noobs_defaults, set_dry_run, \
-    end_config_transaction
+    end_config_transaction, check_corrupt_config
 from kano_settings.system.audio import is_HDMI, set_to_HDMI
 from kano_settings.system.overclock_chip_support import check_clock_config_matches_chip
 
@@ -153,15 +153,19 @@ def get_screen_information():
     return info
 
 
+# Shared reboot flag for reconfiguring for rpi1/2 and video
+reboot_now = False
+
 # main program
 enforce_pi()
 enforce_root('Need to be root!')
 
+# Check for corrupt config file
+if check_corrupt_config():
+    reboot_now = True
+
 # Gather and log data about the current screen
 screen_data = get_screen_information()
-
-# Shared reboot flag for reconfiguring for rpi1/2 and video
-reboot_now = False
 
 # Rpi1 and Rpi2 have different clock rate defaults, but only one
 # set of config options. Swap the config options if we have booted on the other

--- a/boot_default/config.txt
+++ b/boot_default/config.txt
@@ -1,0 +1,69 @@
+# uncomment if you get no picture on HDMI for a default "safe" mode
+#hdmi_safe=1
+
+# Force sound to go through the analog output even if an HDMI monitor is plugged in
+# Not strictly necessary for most apps that default to local device (sonic-pi).
+hdmi_ignore_edid_audio=1
+
+# 1 -> perfect size
+# 0 -> added black border for TVs
+disable_overscan=1
+
+# Use the following to adjust overscan. Use positive numbers if console
+# goes off screen, and negative if there is too much border
+# the zero setting for CEA is -48, for DMT is 0
+overscan_left=0
+overscan_right=0
+overscan_top=0
+overscan_bottom=0
+
+# Force RGB full range (0-255)
+hdmi_pixel_encoding=2
+
+# Force Kanux display size.
+#framebuffer_width=1024
+#framebuffer_height=768
+
+# uncomment if hdmi display is not detected and composite is being output
+hdmi_force_hotplug=1
+
+# uncomment to force a specific HDMI mode (this will force VGA)
+#hdmi_group=1
+#hdmi_mode=1
+
+# uncomment to force a HDMI mode rather than DVI. This can make audio work in
+# DMT (computer monitor) modes
+#hdmi_drive=2
+
+# uncomment to increase signal to HDMI, if you have interference, blanking, or
+# no display
+#config_hdmi_boost=4
+
+# uncomment for composite PAL
+#sdtv_mode=2
+
+# Enabling Turbo Mode
+# Please, beware "force_turbo=1" will set the sticky bit
+# on your RPi unit forever.
+#
+force_turbo=0
+arm_freq=900
+core_freq=250
+sdram_freq=450
+over_voltage=0
+
+# set memory split: amount allocated to the GPU in MB.
+gpu_mem=128
+
+# Toggles PiCamera on(1) and off(0)
+start_x=0
+
+# Set max_usb_current flag to 1 if you need to drive usb devices > 500ma current
+# Note: RaspberryPI model B+ only
+max_usb_current=0
+
+# Enable I2C to allow speaker LEDs to work.
+dtparam=i2c_arm=on
+dtparam=i2c1=on
+
+# for more options see http://elinux.org/RPi_config.txt

--- a/debian/kano-settings.install
+++ b/debian/kano-settings.install
@@ -24,6 +24,8 @@ etc/init.d /etc
 
 etc_override /usr/share/kano-settings
 
+boot_default /usr/share/kano-settings
+
 overscan/overscan /usr/bin
 
 WHITELIST /usr/share/kano-settings/config/

--- a/kano_settings/boot_config.py
+++ b/kano_settings/boot_config.py
@@ -333,11 +333,11 @@ class ConfigTransaction:
             path = self.temp_path
         else:
             path = self.path
-        shutil.copy2(path, boot_config_safemode_backup_path)
+        shutil.copy2(path, dest)
 
     def copy_from(self, src):
         self.set_state_writable()
-        shutil.copy2(boot_config_safemode_backup_path, self.temp_path)
+        shutil.copy2(src, self.temp_path)
 
     def check_corrupt_config(self):
         self.raise_state_to_locked()


### PR DESCRIPTION
@alex5imon @skarbat @pazdera 
This PR is for https://github.com/KanoComputing/peldins/issues/2170
It performs simple (not exhaustive) checks on config.txt and restores a default one if anything alarming is seen. Currently, it only checks for the presence of two parameters chosen from different locations  in the file.
This PR makes a copy of the config.txt from peldins. To avoid divergence, I will later make a PR for peldins which copies this file into `/boot` during the build, after kano-setttings has been installed.