### PR TITLE
Parental: Permit setting lowest setting

### DIFF
--- a/kano_settings/system/advanced.py
+++ b/kano_settings/system/advanced.py
@@ -586,7 +586,7 @@ def write_blacklisted_sites(blacklist):
 
 
 def set_parental_level(level_setting):
-    set_setting('Parental-level', max(level_setting, 1))
+    set_setting('Parental-level', max(level_setting, 0))
 
     # NB, we pass -1 to disable all
     feature_levels = [


### PR DESCRIPTION
KanoComputing/peldins#2270
When setting the parental level, the GUI setting is saved also with a
prevention mechanism for setting the value too low. This minimum was
maligned with the numbering for the parental setting which prevented the
lowest setting from being configured. Resolve this by correcting the
minimum setting.

cc @pazdera 