### PR TITLE
Whitelisting Cloudinary

### DIFF
--- a/WHITELIST
+++ b/WHITELIST
@@ -4,6 +4,7 @@
 
 kano.me
 amazonaws.com
+cloudinary.com
 
 # Updater
 raspbian.org


### PR DESCRIPTION
Kano world will move their images to Cloudinary (http://cloudinary.com/) at some point. Whitelisting it on the OS.

This would break quite a few things (the shares widget, kano apps and kano world when the ultimate parental lock is on).

cc @alex5imon @tombettany @arifshanji @andreiconstantinescu 