### PR TITLE
Add methods to switch to/from the experimental GL graphics driver.

### DIFF
--- a/bin/kano-settings-cli
+++ b/bin/kano-settings-cli
@@ -18,6 +18,7 @@ if __name__ == '__main__' and __package__ is None:
         sys.path.insert(1, dir_path)
 
 from kano_settings.system.keyboard_config import set_saved_keyboard
+from kano_settings.system.display import get_gfx_driver, set_gfx_driver
 from kano_settings.config_file import get_setting
 
 verbose = False
@@ -48,6 +49,14 @@ def parse_args():
             if args['--load']:
                 set_saved_keyboard()
                 print_v('Setting keyboard to value loaded from settings')
+        elif args['gfx_driver']:
+            if args['enable']:
+                set_gfx_driver(True)
+            elif args['disable']:
+                set_gfx_driver(False)
+            
+                
+                
     elif args['get']:
         if args['audio']:
             print_v(
@@ -83,6 +92,8 @@ def parse_args():
                     get_setting('Keyboard-variant-index')
                 )
             )
+        elif args['gfx_driver']:
+            print 'gfx_driver: {}'.format(get_gfx_driver())
 
 if __name__ == "__main__":
     args = docopt("""
@@ -92,6 +103,8 @@ if __name__ == "__main__":
       kano-settings-cli [-v | --verbose] get keyboard
       kano-settings-cli [-v | --verbose] set keyboard (--layout <layout_code> | --load)
       kano-settings-cli [-v | --verbose] get network
+      kano-settings-cli [-v | --verbose] get gfx_driver
+      kano-settings-cli [-v | --verbose] set gfx_driver (enable | disable)
       kano-settings-cli -h | --help
 
     Options:
@@ -101,6 +114,8 @@ if __name__ == "__main__":
       load      Set the keyboard to the value saved by Kano-Settings
       network   Get the network info
       verbose   Verbose mode
+      enable    enable gfx_driver driver
+      disable   disable gfx_driver driver
     """)
 
     parse_args()

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Build-Depends: debhelper (>= 9), build-essential, pkg-config, libgtk2.0-dev,
 Package: kano-settings
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, kano-connect (= ${binary:Version}),
-         python, python-gi, dante-client, kano-toolset (>= 2.3.0-4),
+         python, python-gi, dante-client, kano-toolset (>= 2.3.0-6),
          kano-profile (>= 2.1-1), gir1.2-gtk-3.0, libkdesk-dev, sentry (>= 0.5-0),
          python-bs4, python-pycountry, kano-i18n, libnss-mdns, avahi-daemon,
          kano-content

--- a/kano_settings/config_file.py
+++ b/kano_settings/config_file.py
@@ -44,7 +44,8 @@ defaults = {
         'Wallpaper': 'kanux-background',
         'Parental-level': 0,
         'Locale': 'en_US',
-        'LED-Speaker-anim': False
+        'LED-Speaker-anim': False,
+        'Use_GLX': False
     },
     'pi2': {
         'Keyboard-continent-index': 1,
@@ -62,7 +63,8 @@ defaults = {
         'Wallpaper': 'kanux-background',
         'Parental-level': 0,
         'Locale': 'en_US',
-        'LED-Speaker-anim': True
+        'LED-Speaker-anim': True,
+        'Use_GLX': False
     }
 }
 


### PR DESCRIPTION
This PR adds an a way to switch to the new driver, if it is installed, for testing.
There will be another PR for kano-desktop to start xcompmgr if necessary.
It saves `/usr/share/X11/xorg.conf.d/99-fbturbo.conf`, which is actually from `xserver-xorg-video-fbturbo`, in `/var/cache`, and only restores it if there is not one there already (therefore hopefully avoiding overwriting it if it is written by upgrading that package).
@tombettany @radujipa @alex5imon 