### PR TITLE
Fix low level parental control

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Package: kano-settings
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, kano-connect (= ${binary:Version}),
          python, python-gi, dante-client, kano-toolset (>= 2.4.0-1),
-         kano-profile (>= 2.1-1), gir1.2-gtk-3.0, libkdesk-dev, sentry (>= 0.5-0),
+         kano-profile (>= 2.1-1), gir1.2-gtk-3.0, libkdesk-dev, sentry (>= 0.5-1),
          python-bs4, python-pycountry, kano-i18n, libnss-mdns, avahi-daemon,
          kano-content, bluetooth
 Recommends: kano-fonts


### PR DESCRIPTION
This PR is intended to fix https://github.com/KanoComputing/peldins/issues/2294. It needs more testing.
Making a PR only to remember why this branch exists and link it to the issue.
 - sentry dns is now used for low level as well as ultimate level.
 - In low level, sentry is used to map *.(google|youtube).*DOMAIN to
   forcesafesearch.google.com
 - Cookie manipulation is no longer required
This depends on a patched version of sentry (version 0.5.1) (https://github.com/KanoComputing/sentry/pull/2)
