### PR TITLE
Fixing kano-settings keyboard sometimes failing

### DIFF
--- a/kano_settings/set_keyboard.py
+++ b/kano_settings/set_keyboard.py
@@ -185,12 +185,12 @@ class SetKeyboard(Template):
                 # The callback runs a GUI task, so wrap it!
                 GObject.idle_add(self.work_finished_cb)
 
-            # Apply changes
+            # Save the changes in the config file
+            self.update_config()
+
+            # An then apply the new saved changes
             thread = threading.Thread(target=lengthy_process)
             thread.start()
-
-            # Save the changes in the config
-            self.update_config()
 
             kano_keyboard = detect_kano_keyboard()
 


### PR DESCRIPTION
 * A thread was started to apply the new changes (read), and right
   after that a call to save them was being called (write),
   the apply would sometimes crash because the file would be empty.

 * Fixed by saving the settings first, then start the thread to apply them.

@Ealdwulf this PR would replace this one: https://github.com/KanoComputing/kano-toolset/pull/208

Tested briefly and seems to fix it. What do you think?
