### PR TITLE
Dependencies: Depend on new libkano-networking package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Priority: optional
 Standards-Version: 3.9.2
 Build-Depends: debhelper (>= 9), build-essential, pkg-config, libgtk2.0-dev,
                lxpanel (>= 0.7.0), libfm-dev, libkdesk-dev,
-               kano-toolset (>= 2.4.0)
+               libkano-networking-dev
 
 Package: kano-settings
 Architecture: any
@@ -22,6 +22,6 @@ Description: Graphical tool to set different system settings
 Package: kano-connect
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, python, udhcpc,
-         rxvt-unicode-256color, kano-toolset, libkdesk-dev
+         rxvt-unicode-256color, kano-toolset, libkdesk-dev, libkano-networking
 Description: Software to make Kanux connect over Wireless networks
  automatically.


### PR DESCRIPTION
The `libkano_networking` library was split from the `kano-toolset`
package into its own package. Depend on this package instead.

Required after https://github.com/KanoComputing/kano-toolset/pull/206.