### PR TITLE
Fix sentry startup

### DIFF
--- a/bin/start-sentry-server
+++ b/bin/start-sentry-server
@@ -12,6 +12,7 @@ import sys
 import os
 from kano_settings.system.advanced import (sentry_config,
                                            parse_whitelist_to_config_file,
+                                           make_safesearch_config_file,
                                            launch_sentry_server)
 from kano_settings.common import settings_dir
 from kano.logging import logger
@@ -19,7 +20,7 @@ from kano.logging import logger
 
 def check_config():
     # Look at the setting to find the parental level
-    ultimate_parental = False
+    use_sentry = False
 
     settings_config = os.path.join(settings_dir, 'settings')
     if not os.path.exists(settings_config):
@@ -28,19 +29,25 @@ def check_config():
 
     f = open(settings_config, 'r')
 
-    # Check if the parental control is at the highest level 3.0
+    # Check if the parental control is at a level in which sentry is used
     for line in f:
         line = line.strip()
-        if '"Parental-level": 3.0' in line:
-            ultimate_parental = True
-            logger.debug("Ultimate parental control set in line {}".format(line))
+        whitelist = '"use_sentry": "whitelist"' in line
+        safesearch = '"use_sentry": "safesearch"' in line
+        if whitelist or safesearch:
+            use_sentry = True
+            logger.debug("Sentry use set in line {}".format(line))
         else:
-            logger.debug("Ultimate parental control is NOT set in line {}".format(line))
+            logger.debug("Sentry use is NOT set in line {}".format(line))
 
     # If the parental is at the highest level, start the sentry server
-    if ultimate_parental:
+    if use_sentry:
         # Functions contain logs
-        parse_whitelist_to_config_file(sentry_config)
+        if whitelist:
+            parse_whitelist_to_config_file(sentry_config)
+        else:
+            make_safesearch_config_file(sentry_config)
+
         launch_sentry_server(sentry_config)
         sys.exit(0)
 

--- a/bin/start-sentry-server
+++ b/bin/start-sentry-server
@@ -12,7 +12,6 @@ import sys
 import os
 from kano_settings.system.advanced import (sentry_config,
                                            parse_whitelist_to_config_file,
-                                           make_safesearch_config_file,
                                            launch_sentry_server)
 from kano_settings.common import settings_dir
 from kano.logging import logger
@@ -46,7 +45,8 @@ def check_config():
         if whitelist:
             parse_whitelist_to_config_file(sentry_config)
         else:
-            make_safesearch_config_file(sentry_config)
+            # No need to rebuild safesearch config, as it doesn't change
+            pass
 
         launch_sentry_server(sentry_config)
         sys.exit(0)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kano-settings (3.2.0-1) unstable; urgency=low
+
+  * Remove kano_settings.system.advanced.set_user_cookies API
+
+ -- Team Kano <dev@kano.me>  Thu, 5 May 2016 11:00:00 +0100
+
 kano-settings (2.3.0-1) unstable; urgency=low
 
   * Extending the wallpaper settings API with a getter function

--- a/debian/control
+++ b/debian/control
@@ -15,6 +15,7 @@ Depends: ${shlibs:Depends}, ${misc:Depends}, kano-connect (= ${binary:Version}),
          python-bs4, python-pycountry, kano-i18n, libnss-mdns, avahi-daemon,
          kano-content, bluetooth, pi-bluetooth
 Recommends: kano-fonts
+Breaks: kano-init (<<3.2.0-1)
 Description: Graphical tool to set different system settings
  This application is a GUI frontend to set multiple Kano OS functionalities
  like Wireless, Keyboard layout, Screen options, and Proxy.

--- a/kano_settings/system/advanced.py
+++ b/kano_settings/system/advanced.py
@@ -342,8 +342,10 @@ def set_ultimate_parental(ultimate, safesearch):
         restore_dns_interfaces()
         redirect_traffic_to_google()
         if ultimate:
+            set_setting("use_sentry", "whitelist")
             parse_whitelist_to_config_file(sentry_config)
         elif safesearch:
+            set_setting("use_sentry", "safesearch")
             make_safesearch_config_file(sentry_config)
 
         # Now set resolv.conf to point to localhost
@@ -351,10 +353,13 @@ def set_ultimate_parental(ultimate, safesearch):
         redirect_traffic_to_localhost()
         launch_sentry_server(sentry_config)
 
+
     else:
         restore_dns_interfaces()
         redirect_traffic_to_google()
         kill_server()
+
+        set_setting("use_sentry", "")
 
 
 def redirect_traffic_to_google():

--- a/kano_settings/system/advanced.py
+++ b/kano_settings/system/advanced.py
@@ -294,7 +294,7 @@ def set_hosts_blacklist(enable, block_search,
             logger.debug('skipping, hosts file is already too big')
         else:
             logger.debug('making a backup of the original hosts file')
-            shutil.copyfile(hosts_file, hosts_file_backup)
+            shutil.copy(hosts_file, hosts_file_backup)
 
             logger.debug('appending the blacklist file')
             zipped_blacklist = gzip.GzipFile(blacklist_file)

--- a/kano_settings/system/advanced.py
+++ b/kano_settings/system/advanced.py
@@ -285,6 +285,10 @@ def set_hosts_blacklist(enable, block_search,
     if enable:
         logger.debug('enabling blacklist')
 
+        if os.path.exists(hosts_file_backup):
+            logger.debug('restoring original backup file')
+            shutil.copy(hosts_file_backup, hosts_file)
+
         # sanity check: this is a big file, looks like the blacklist is already in place
         if os.path.getsize(hosts_file) > 10000:
             logger.debug('skipping, hosts file is already too big')


### PR DESCRIPTION
This PR fixes a few issues missed in merging #360 : 
* sentry wasn't being restarted at boot except in ultimate parental mode (it is now required in all parental control modes except 'off') 
* opendns wasn't being used (because it now needs to be used at the same time as sentry)
Unrelated to #360, changing between different parental control modes wasn't changing the hosts file, so, eg, going to mode 2 wan't adding search engines to the blacklist if you were already in mode 1, because the loging which wrote the hosts file had a check that assumed that the hosts file couldn't need changing if we it was 'already big'.
Therefore when we are in a parental control mode I have added  code to restore the backup hosts file before appending the blacklist. I think this shoudl be okay (after all, we already restore it when coming out of parental control, so this is effectively like doing that and then going back in). But I don't understand why we didn't do it that way before. Any ideas @skarbat @tombettany ?

There are a number cases here, so I'd like to get it merged soon, so I can ask GAT to test it. 
@alex5imon 