### PR TITLE
Use alsa-store instead of the deprecated alsa-utils.

### DIFF
--- a/etc/init.d/kano-bootup-sound
+++ b/etc/init.d/kano-bootup-sound
@@ -2,7 +2,7 @@
 
 ### BEGIN INIT INFO
 # Provides:          kano-bootup-sound
-# Required-Start:    $alsa-utils
+# Required-Start:    $alsa-restore
 # Required-Stop:
 # Default-Start:     2
 # Default-Stop:

--- a/etc/kano-rc.local
+++ b/etc/kano-rc.local
@@ -14,7 +14,7 @@
 #
 
 #
-# NB audio is no loger controlled here, we just rely on alsa-utils.
+# NB audio is no longer controlled here, we just rely on alsa-(re)store.
 #
 
 /etc/rc.network

--- a/kano_settings/system/audio.py
+++ b/kano_settings/system/audio.py
@@ -20,7 +20,7 @@ analogue_value = 1
 hdmi_value = 2
 hdmi_string = ": values={}".format(hdmi_value)
 
-store_cmd = "service alsa-utils restart"
+store_cmd = "service alsa-store restart"
 #amixer_set_cmd = "amixer -c 0 cset {control} {{value}}".format(
 #    control=amixer_control)
 amixer_get_cmd = "amixer -c 0 cget {control}".format(control=amixer_control)
@@ -81,10 +81,10 @@ def set_to_HDMI(HDMI):
     if rc:
         logger.warn("error from amixer: {} {} {}".format(o, e, rc))
 
-    # trigger alsa-utils to store the path in /var/lib/alsa/asound.state
+    # trigger alsa-store to store the path in /var/lib/alsa/asound.state
     o, e, rc = run_cmd(store_cmd)
     if rc:
-        logger.warn("error from alsa-utils: {} {} {}".format(o, e, rc))
+        logger.warn("error from alsa-store: {} {} {}".format(o, e, rc))
 
     set_setting('Audio', config)
     return config


### PR DESCRIPTION
This PR updates kano-settings to use alsa-store instead of the deprecated alsa-utils.
@radujipa 
kano-boot-up sound is also changed to depend on alsa-restore instead of kano-utils.