### PR TITLE
Don't change the config if the pi is not recognised

### DIFF
--- a/kano_settings/system/overclock_chip_support.py
+++ b/kano_settings/system/overclock_chip_support.py
@@ -48,7 +48,14 @@ def check_clock_config_matches_chip():
     """
 
     current_model = get_rpi_model()
+
     current_model_profile = get_board_property(current_model, 'cpu_profile')
+
+    if current_model_profile is None:
+        logger.error('Unknown pi model {}, not messing with config.txt',
+                     current_model)
+        return False
+
     old_model_profile = overclock.get_matching_board_profile()
     logger.debug('Checked the two boards, the old one is {} type '
                  'and the new one is {} type'


### PR DESCRIPTION
A pi in the workshop was seen to get confused about restoring config.txt because it did not have the fix for https://github.com/KanoComputing/peldins/issues/2366. This PR makes this path more robust in the event that future pis have more revision numbers.
@tombettany @skarbat   
Not necessary to merge for 3.3