### PR TITLE
Support for building spanish image with keyboard settings.

### DIFF
--- a/bin/kano-settings-cli
+++ b/bin/kano-settings-cli
@@ -18,7 +18,7 @@ if __name__ == '__main__' and __package__ is None:
     if dir_path != '/usr':
         sys.path.insert(1, dir_path)
 
-from kano_settings.system.keyboard_config import set_saved_keyboard
+from kano_settings.system.keyboard_config import set_saved_keyboard, set_keyboard
 from kano_settings.system.display import get_gfx_driver, set_gfx_driver, \
     read_overscan_values, write_overscan_values
 from kano_settings.config_file import get_setting
@@ -60,6 +60,20 @@ def parse_args():
             if args['--load']:
                 set_saved_keyboard()
                 print_v('Setting keyboard to value loaded from settings')
+            elif args['--layout']:
+                a = args['<layout_code>']
+                alist = a.split(' ')
+                if len(alist) >= 1:
+                    cc = alist[0]
+                else:
+                    cc = 'en_US'
+                if len(alist) >= 2:
+                    variant = alist[1]
+                else:
+                    variant = 'generic'
+                set_keyboard(cc, variant)
+                print_v('Setting keyboard to {} {}'.format(cc, variant))
+
         elif args['gfx_driver']:
             if args['enable']:
                 set_gfx_driver(True)

--- a/kano_settings/system/keyboard_config.py
+++ b/kano_settings/system/keyboard_config.py
@@ -9,7 +9,8 @@
 # based on country name and local keyboard variant.
 #
 
-from kano.utils import run_cmd
+from kano.utils.shell import run_cmd
+from kano.utils.file_operations import sed
 import kano_settings.system.keyboard_layouts as keyboard_layouts
 from kano_settings.config_file import get_setting
 
@@ -61,13 +62,25 @@ def is_changed(country_code, variant):
     return (country_code != stored_layout or variant != stored_variant)
 
 
+def set_keyboard_config(country_code, variant):
+    sed('^XKBLAYOUT=.*$',
+        'XKBLAYOUT="{}"'.format(country_code),
+        keyboard_conffile,
+        True)
+    sed('^XKBVARIANT=.*$',
+        'XKBVARIANT="{}"'.format(variant),
+        keyboard_conffile,
+        True)
+
+
 def set_keyboard(country_code, variant):
     if variant == 'generic':
         variant = ''
 
     # Notify and apply changes to the XServer
     run_cmd("setxkbmap {} {}".format(country_code, variant))
-
+    set_keyboard_config(country_code, variant)
+    run_cmd("ACTIVE_CONSOLE=guess /bin/setupcon -k </dev/tty1")
 
 def set_saved_keyboard():
     continent = get_setting('Keyboard-continent-human')


### PR DESCRIPTION
This PR implements the missing the `set keyboard  --layout` option in kano-settings cli, which is used in the es_AR overnight image build.
It makes set_keyboard save the keyboard setting in /etc/default/keyboard, and also makes it set the console setting.

@skarbat @tombettany 