### PR TITLE
Keyboard locale: Allow setting the keyboard from the CLI

### DIFF
--- a/bin/kano-settings-cli
+++ b/bin/kano-settings-cli
@@ -61,18 +61,21 @@ def parse_args():
                 set_saved_keyboard()
                 print_v('Setting keyboard to value loaded from settings')
             elif args['--layout']:
-                a = args['<layout_code>']
-                alist = a.split(' ')
-                if len(alist) >= 1:
-                    cc = alist[0]
+                layout_code = args['<layout_code>']
+                layout_code_list = layout_code.split(' ')
+
+                if len(layout_code_list) >= 1:
+                    locale = layout_code_list[0]
                 else:
-                    cc = 'en_US'
-                if len(alist) >= 2:
-                    variant = alist[1]
+                    locale = 'en_US'
+
+                if len(layout_code_list) >= 2:
+                    variant = layout_code_list[1]
                 else:
                     variant = 'generic'
-                set_keyboard(cc, variant)
-                print_v('Setting keyboard to {} {}'.format(cc, variant))
+
+                set_keyboard(locale, variant, save=True)
+                print_v('Setting keyboard to {} {}'.format(locale, variant))
 
         elif args['gfx_driver']:
             if args['enable']:

--- a/kano_settings/set_keyboard.py
+++ b/kano_settings/set_keyboard.py
@@ -77,7 +77,7 @@ class SetKeyboard(Template):
     selected_country_hr = "USA"
     selected_variant_hr = "generic"
     variants_combo = None
-    continents = ['Africa', 'America', 'Asia', 'Australia', 'Europe', 'Others']
+    continents = keyboard_layouts.get_continents()
     kano_keyboard = True
 
     def __init__(self, win):
@@ -211,22 +211,14 @@ class SetKeyboard(Template):
         self.selected_variant_hr = get_setting("Keyboard-variant-human")
 
     def update_config(self):
-        logger.info('set_keyboard.update_config {} {} {} {} {} {}'.format(
+        keyboard_config.update_settings_keyboard_conf(
             self.selected_continent_index,
             self.selected_country_index,
             self.selected_variant_index,
             self.selected_continent_hr,
             self.selected_country_hr,
             self.selected_variant_hr
-        ))
-
-        # Add new configurations to config file.
-        set_setting("Keyboard-continent-index", self.selected_continent_index)
-        set_setting("Keyboard-country-index", self.selected_country_index)
-        set_setting("Keyboard-variant-index", self.selected_variant_index)
-        set_setting("Keyboard-continent-human", self.selected_continent_hr)
-        set_setting("Keyboard-country-human", self.selected_country_hr)
-        set_setting("Keyboard-variant-human", self.selected_variant_hr)
+        )
 
     # setting = "variant", "continent" or "country"
     def set_defaults(self, setting):
@@ -352,10 +344,9 @@ class SetKeyboard(Template):
     def fill_countries_combo(self, continent):
         continent = continent.lower()
 
-        try:
-            self.selected_layout = keyboard_layouts.layouts[continent]
-        except KeyError:
-            return
+        self.selected_layout = keyboard_layouts.get_countries_for_continent(
+            continent
+        )
 
         self.selected_continent_hr = continent
 
@@ -364,7 +355,7 @@ class SetKeyboard(Template):
         self.variants_combo.remove_all()
 
         # Get a sorted list of the countries from the dict layout
-        sorted_countries = sorted(self.selected_layout)
+        sorted_countries = keyboard_layouts.sorted_countries(continent)
 
         # Refresh countries combo box
         for country in sorted_countries:

--- a/kano_settings/system/keyboard_config.py
+++ b/kano_settings/system/keyboard_config.py
@@ -9,10 +9,13 @@
 # based on country name and local keyboard variant.
 #
 
+from kano.logging import logger
 from kano.utils.shell import run_cmd
 from kano.utils.file_operations import sed
+
 import kano_settings.system.keyboard_layouts as keyboard_layouts
-from kano_settings.config_file import get_setting
+import kano_settings.system.locale as locale
+from kano_settings.config_file import get_setting, set_setting
 
 # GLOBAL variables
 keyboard_conffile = '/etc/default/keyboard'
@@ -62,6 +65,26 @@ def is_changed(country_code, variant):
     return (country_code != stored_layout or variant != stored_variant)
 
 
+def update_settings_keyboard_conf(continent_index, country_index, variant_index,
+                                  continent, country, variant):
+    logger.info('set_keyboard.update_config {} {} {} {} {} {}'.format(
+        continent_index,
+        country_index,
+        variant_index,
+        continent,
+        country,
+        variant
+    ))
+
+    # Add new configurations to config file.
+    set_setting("Keyboard-continent-index", continent_index)
+    set_setting("Keyboard-country-index", country_index)
+    set_setting("Keyboard-variant-index", variant_index)
+    set_setting("Keyboard-continent-human", continent)
+    set_setting("Keyboard-country-human", country)
+    set_setting("Keyboard-variant-human", variant)
+
+
 def set_keyboard_config(country_code, variant):
     sed('^XKBLAYOUT=.*$',
         'XKBLAYOUT="{}"'.format(country_code),
@@ -73,7 +96,36 @@ def set_keyboard_config(country_code, variant):
         True)
 
 
-def set_keyboard(country_code, variant):
+def save_keyboard_settings(locale_code, variant):
+    continent, country = locale.locale_to_layout_keys(locale_code)
+    continent_idx, country_idx = locale.layout_keys_to_indexes(
+        continent, country
+    )
+
+    country_code = keyboard_layouts.layouts.get(continent, {}).get(country, '')
+    variants = find_keyboard_variants(country_code) or []
+
+    found = False
+    idx = 0
+
+    for idx, (variant_desc, variant_id) in enumerate(variants):
+        if variant_desc == variant or variant_id == variant:
+            found = True
+            break
+
+    variant_idx = idx if found else 0
+
+    update_settings_keyboard_conf(
+        continent_idx,
+        country_idx,
+        variant_idx,
+        continent,
+        country,
+        variant
+    )
+
+
+def set_keyboard(country_code, variant, save=False):
     if variant == 'generic':
         variant = ''
 
@@ -81,6 +133,10 @@ def set_keyboard(country_code, variant):
     run_cmd("setxkbmap {} {}".format(country_code, variant))
     set_keyboard_config(country_code, variant)
     run_cmd("ACTIVE_CONSOLE=guess /bin/setupcon -k </dev/tty1")
+
+    if save:
+        save_keyboard_settings(country_code, variant)
+
 
 def set_saved_keyboard():
     continent = get_setting('Keyboard-continent-human')

--- a/kano_settings/system/keyboard_layouts.py
+++ b/kano_settings/system/keyboard_layouts.py
@@ -1,16 +1,17 @@
-#!/usr/bin/env python
-
+#
 # keyboard_layouts.py
 #
-# Copyright (C) 2014 Kano Computing Ltd.
-# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+# Copyright (C) 2014-2016 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
 #
-# Country code mappings to keyboard model names, and keyboard variant names collected from
-# Debian console-setup source package, version 1.88: http://packages.debian.org/source/wheezy/console-setup
+# Country code mappings to keyboard model names, and keyboard variant names
+# collected from Debian console-setup source package, version 1.88:
+#     http://packages.debian.org/source/wheezy/console-setup
 # http://dev.kano.me/public/Keyboardnames.pl.txt
 #
 # Mapping of country names to keyboard layout codes,
-# With additional names for natural country prompts (for example United Kingdom, England, UK, etc)
+# With additional names for natural country prompts (for example United Kingdom,
+# England, UK, etc)
 
 layouts = {
     'europe': {
@@ -674,3 +675,19 @@ variants = {
     ]
 
 }
+
+def get_continents():
+    return [
+        'Africa',
+        'America',
+        'Asia',
+        'Australia',
+        'Europe',
+        'Others'
+    ]
+
+def get_countries_for_continent(continent):
+    return layouts.get(continent.lower(), [])
+
+def sorted_countries(countries):
+    return sorted(countries)


### PR DESCRIPTION
https://trello.com/c/B07XgJVB/201-get-kano-settings-cli-to-implement-setting-keybaord-layout

The CLI is used to configure the locale settings for the image at build
time. As such, expose the keyboard setting interface and unify it with
the GUI setting.

cc @Ealdwulf 