### PR TITLE
Keyboard setup fixes

### DIFF
--- a/kano_settings/set_keyboard.py
+++ b/kano_settings/set_keyboard.py
@@ -13,7 +13,7 @@ import kano_settings.system.keyboard_layouts as keyboard_layouts
 import kano_settings.system.keyboard_config as keyboard_config
 import kano_settings.common as common
 from kano_settings.templates import Template
-from kano_settings.config_file import get_setting, set_setting
+from kano_settings.config_file import get_setting
 from kano.gtk3.buttons import OrangeButton
 from kano.gtk3.kano_combobox import KanoComboBox
 from kano.utils import detect_kano_keyboard
@@ -355,7 +355,9 @@ class SetKeyboard(Template):
         self.variants_combo.remove_all()
 
         # Get a sorted list of the countries from the dict layout
-        sorted_countries = keyboard_layouts.sorted_countries(continent)
+        sorted_countries = keyboard_layouts.sorted_countries(
+            self.selected_layout
+        )
 
         # Refresh countries combo box
         for country in sorted_countries:

--- a/kano_settings/system/keyboard_config.py
+++ b/kano_settings/system/keyboard_config.py
@@ -125,17 +125,17 @@ def save_keyboard_settings(locale_code, variant):
     )
 
 
-def set_keyboard(country_code, variant, save=False):
+def set_keyboard(locale_code, variant, save=False):
     if variant == 'generic':
         variant = ''
 
     # Notify and apply changes to the XServer
-    run_cmd("setxkbmap {} {}".format(country_code, variant))
-    set_keyboard_config(country_code, variant)
+    run_cmd("setxkbmap {} {}".format(locale_code, variant))
+    set_keyboard_config(locale.split_locale(locale_code)[0], variant)
     run_cmd("ACTIVE_CONSOLE=guess /bin/setupcon -k </dev/tty1")
 
     if save:
-        save_keyboard_settings(country_code, variant)
+        save_keyboard_settings(locale_code, variant)
 
 
 def set_saved_keyboard():

--- a/kano_settings/system/keyboard_config.py
+++ b/kano_settings/system/keyboard_config.py
@@ -38,7 +38,7 @@ def find_keyboard_variants(country_code):
         return None
 
 
-# Find macintosh index within the variants combobox 
+# Find macintosh index within the variants combobox
 def find_macintosh_index(country_name, layout):
     country_code = find_country_code(country_name, layout)
     variants = find_keyboard_variants(country_code)


### PR DESCRIPTION
Fixes https://trello.com/c/Zf6k4Oy9/73-kano-init-font-is-too-smal

After quite a lot of investigation I found out the reason as to why the console font on the Spanish image is tiny is because, when [setting up the keyboard layout]( https://github.com/KanoComputing/peldins/blob/69ee1718fe5d072c7f158ab06bc97ee20767fb2c/Makefile#L546), `kano_settings` sets the `XKBLAYOUT` in `/etc/default/keyboard` to `es_AR` which is not recognised and so the console setup fails. The fix was to set `XKBLAYOUT` to just `es` which works fine.

I also fixed a bug in the keyboard settings page that prevented it from displaying on the english image.

cc. @Ealdwulf @radujipa 