### PR TITLE
Fix set to uncomment setting

### DIFF
--- a/kano_settings/boot_config.py
+++ b/kano_settings/boot_config.py
@@ -125,7 +125,7 @@ class BootConfig:
         logger.info('writing value to {} {} {}'.format(self.path, name, value))
 
         config = BootConfigParser(lines)
-        config.set(name, value if value else '0', config_filter=config_filter)
+        config.set(name, value, config_filter=config_filter)
 
         with open_locked(self.path, "w") as boot_config_file:
             boot_config_file.write(config.dump())

--- a/kano_settings/system/boot_config/boot_config_parser.py
+++ b/kano_settings/system/boot_config/boot_config_parser.py
@@ -104,6 +104,8 @@ class BootConfigParser(object):
             ).value
 
     def set(self, setting, value, config_filter=Filter.ALL):
+        # NB if value is None, we comment out the setting
+        # If the value is not None, we uncomment the setting and set it to the value
         search = {
             'setting': setting,
             'filter': config_filter
@@ -111,14 +113,20 @@ class BootConfigParser(object):
 
         for line in reversed(self.config):
             if line == search:
-                line.value = value
+                line.value = value or 0
+                line.is_comment = value is None
+                line.is_commented_out = value is None
+                line.is_manual_comment = False
                 return
 
         new_line = BootConfigLine({
             'setting': setting,
             'filter': config_filter,
-            'value': value
+            'value': value or 0,
+            'is_comment': value is None,
+            'is_commented_out': value is None
         })
+
         self.add(new_line)
 
     def dump(self):

--- a/tests/boot_config/boot_config_parser.py
+++ b/tests/boot_config/boot_config_parser.py
@@ -248,7 +248,8 @@ class CheckSettingConfigValues(BootConfigParserTest):
 
         sdtv_mode = self.config.get_line('sdtv_mode')
         self.assertEqual(sdtv_mode.value, new_val)
-        self.assertEqual(sdtv_mode.is_comment, True)
+        # Setting a commented value uncomments it
+        self.assertEqual(sdtv_mode.is_comment, False)
 
     def test_setting_compound_key(self):
         new_val = 'off'


### PR DESCRIPTION
This PR fixes set_config_value to make sure the setting is uncommented if you call "set_config_value()",
unless the value it is passed is None, in which case it comments out the setting.
* set_config_value() should replace commented out version of the setting.
* Had to extend the representation class (boot_config_line) a bit, to clearly distinguish commented out settings and random comments. Commented out settings always need a '=0'.
Updated the unit test to include commented out settings.
@skarbat @radujipa @tombettany 