### PR TITLE
Fix for unresponsive flip display option in Display

### DIFF
--- a/boot_default/config.txt
+++ b/boot_default/config.txt
@@ -70,9 +70,15 @@ dtparam=spi=on
 # Enable speaker
 dtparam=audio=on
 
+# Rotate the display clockwise on the screen (default=0) or flip the display.
+display_rotate=0
+# Decrease audio noise.
+disable_audio_dither=1
+
 
 # for more options see http://elinux.org/RPi_config.txt
 
+# Configuration Filters
 
 [EDID=ADA-HDMI]
 # Screen kit
@@ -88,6 +94,3 @@ display_rotate=2
 # for light board
 enable_uart=1
 [all]
-
-# Decrease audio noise.
-disable_audio_dither=1


### PR DESCRIPTION
Using an RPi2 with a Screen Kit, it was possible somehow for something to get
confused about the display and write the option at the end. What that means is
that kano-settings will change the display_rotate in one of the Screen Kit
filters which gets ignored by the lowest setting that was incorrectly written
at the end of the file outside the filters.

@tombettany @Ealdwulf @skarbat up to you if you want to merge this for the release. I tested it and it seems to be working.