### PR TITLE
Add boot check

### DIFF
--- a/bin/kano-boot-check
+++ b/bin/kano-boot-check
@@ -6,7 +6,14 @@
 #
 # Check whether the kit has been shut down safely, or the plug has been pulled.
 
-# FIXME add copyright
+# Usage:
+# kano-boot-check (start|stop|test)
+#  start and stop are intended to be run at bootup and shutdown.
+#  kano-boot-check test returns 0 if:
+#    kano-boot-check stop
+#  was run before the last call to
+#    kano-boot-check start
+
 
 ARG=$1
 SENTINEL_DIR=/boot

--- a/bin/kano-boot-check
+++ b/bin/kano-boot-check
@@ -1,0 +1,42 @@
+#!/bin/bash
+# kano-boot-check
+#
+# Copyright (C) 2016 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+#
+# Check whether the kit has been shut down safely, or the plug has been pulled.
+
+# FIXME add copyright
+
+ARG=$1
+SENTINEL_DIR=/boot
+SENTINEL_FILE=${SENTINEL_DIR}/kano_boot_sentinel
+
+case $ARG in
+   start)
+     if [ -f ${SENTINEL_FILE} ] ; then
+        echo "BAD" > ${SENTINEL_FILE}
+        syncfs <${SENTINEL_FILE}
+     else
+        mkdir -p ${SENTINEL_DIR}
+        echo "GOOD" > ${SENTINEL_FILE}
+        syncfs <${SENTINEL_FILE}
+     fi
+     ;;
+
+   stop)
+     rm $SENTINEL_FILE
+     syncfs <$/boot/config.txt
+     ;;
+
+   test)
+     if [ "$(cat ${SENTINEL_FILE})" == "GOOD" ] ; then
+        exit 0;
+     fi
+     exit 1;
+     ;;
+
+   *)
+     exit 1;
+     ;;
+esac

--- a/debian/kano-settings.install
+++ b/debian/kano-settings.install
@@ -6,6 +6,7 @@ bin/kano-safeboot-mode /usr/bin
 bin/regenerate-ssh-keys /usr/bin
 bin/start-sentry-server /usr/bin
 bin/kano-checked-reboot /usr/bin
+bin/kano-boot-check /usr/bin
 bin/kano-capture-logs /usr/bin
 
 kano_settings/* /usr/lib/python2.7/dist-packages/kano_settings

--- a/debian/kano-settings.postinst
+++ b/debian/kano-settings.postinst
@@ -58,6 +58,9 @@ case "$1" in
         # add kano-reboot-clear to startup
         update-rc.d kano-reboot-clear defaults
 
+        # add kano-boot-check to startup
+        update-rc.d kano-boot-check defaults
+
 	# Check for default hostname and set to name of first user
 	python -c "from kano_settings.system.advanced import set_hostname_postinst; set_hostname_postinst()"
 

--- a/debian/kano-settings.postrm
+++ b/debian/kano-settings.postrm
@@ -25,6 +25,18 @@ case "$1" in
         # remove kano-settings-onboot from startup
         update-rc.d kano-settings remove
 
+        # remove kano-safeboot-mode from startup
+        update-rc.d kano-safeboot remove
+
+        # remove kano-bootup-sound from startup
+        update-rc.d kano-bootup-sound remove
+
+        # remove kano-reboot-clear from startup
+        update-rc.d kano-reboot-clear remove
+
+        # remove kano-boot-check from startup
+        update-rc.d kano-boot-check remove
+
         ;;
 esac
 

--- a/etc/init.d/kano-boot-check
+++ b/etc/init.d/kano-boot-check
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+### BEGIN INIT INFO
+# Provides:         kano-boot-check
+# Required-Start:   $local_fs
+# Required-Stop:
+# X-Start-Before:   
+# Default-Start:    2
+# Default-Stop:
+### END INIT INFO
+
+. /lib/lsb/init-functions
+
+case "$1" in
+    start)
+	log_action_begin_msg "Running kano-boot-check"
+	/usr/bin/kano-boot-check start
+	log_action_end_msg $?
+	;;
+    stop)
+	log_action_begin_msg "Stopping kano-boot-check"
+	/usr/bin/kano-boot-check stop
+	log_action_end_msg $?
+	;;
+    restart|reload|force-reload|status)
+        echo "Error: argument '$1' not supported" >&2
+        exit 3
+	;;
+    *)
+      echo "Usage: kano-boot-check [start|stop]" >&2
+      exit 3
+      ;;
+esac
+


### PR DESCRIPTION
This PR adds a program `kano-boot-check` which tests whether the plug was pulled.
It is run at bootup with the argument `start` and shutdown with the argument `stop`. 
To determine if the system was shut down properly, look at the return code of `kano-boot-chek test`
which is successful (0) if it was.
@skarbat @radujipa 
This can be used to implement the warning which is planned for the dashboard.
For https://trello.com/c/UiqoXEkb