### PR TITLE
Fix spurious shutdown warnings on forced reboot

### DIFF
--- a/bin/kano-checked-reboot
+++ b/bin/kano-checked-reboot
@@ -55,4 +55,7 @@ os.close(dirfd)
 
 os.system('sync')
 
+# Mark that we are going down even if we have been told to go down quickly
+os.system("systemctl stop kano-boot-check.service")
+
 os.system(cmd_plus_args)


### PR DESCRIPTION
Sometimes we call reboot without taking down systemd units, which prevents us from
correctly deciding whether the plug has been pulled. Always shut down kano-boot-check.service.

@tombettany @skarbat 
