### PR TITLE
Refresh networks immediately after a weak signal screen failure.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,71 @@
 
-# Created by https://www.gitignore.io/api/vim,macos,python,sublimetext
+# Created by https://www.gitignore.io/api/vim,macos,emacs,python,sublimetext,visualstudiocode
+
+### Emacs ###
+# -*- mode: gitignore; -*-
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+
+# Org-mode
+.org-id-locations
+*_archive
+
+# flymake-mode
+*_flymake.*
+
+# eshell files
+/eshell/history
+/eshell/lastdir
+
+# elpa packages
+/elpa/
+
+# reftex files
+*.rel
+
+# AUCTeX auto folder
+/auto/
+
+# cask packages
+.cask/
+dist/
+
+# Flycheck
+flycheck_*.el
+
+# server auth directory
+/server/
+
+# projectiles files
+.projectile
+projectile-bookmarks.eld
+
+# directory configuration
+.dir-locals.el
+
+# saveplace
+places
+
+# url cache
+url/cache/
+
+# cedet
+ede-projects.el
+
+# smex
+smex-items
+
+# company-statistics
+company-statistics-cache.el
+
+# anaconda-mode
+anaconda-mode/
 
 ### macOS ###
 *.DS_Store
@@ -77,7 +143,6 @@ coverage.xml
 *.cover
 .hypothesis/
 
-
 # Translations
 *.mo
 *.pot
@@ -106,7 +171,7 @@ target/
 .python-version
 
 # celery beat schedule file
-celerybeat-schedule
+celerybeat-schedule.*
 
 # SageMath parsed files
 *.sage.py
@@ -179,4 +244,12 @@ Session.vim
 # auto-generated tag files
 tags
 
-# End of https://www.gitignore.io/api/vim,macos,python,sublimetext
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+.history
+
+# End of https://www.gitignore.io/api/vim,macos,emacs,python,sublimetext,visualstudiocode

--- a/kano_wifi_gui/ConnectToNetwork.py
+++ b/kano_wifi_gui/ConnectToNetwork.py
@@ -38,11 +38,10 @@ class ConnectToNetwork():
         SpinnerScreen(self._win, title, description,
                       self._launch_connect_thread)
 
-    def _go_to_network_screen(self, network_list):
-        from kano_wifi_gui.NetworkScreen import NetworkScreen
+    def _go_to_spinner_screen(self, button=None, event=None):
+        from kano_wifi_gui.RefreshNetworks import RefreshNetworks
 
-        self._win.remove_main_widget()
-        NetworkScreen(self._win, network_list)
+        RefreshNetworks(self._win)
 
     def _thread_finish(self, rc):
         '''
@@ -58,7 +57,7 @@ class ConnectToNetwork():
         else:
             # For now, assume the signal is too weak, because
             # the network was correctly chosen from the scan list.
-            self._weak_signal_screen(self._win)
+            self._weak_signal_screen()
 
     def _wrong_password_screen(self):
         from kano_wifi_gui.PasswordScreen import PasswordScreen
@@ -68,7 +67,7 @@ class ConnectToNetwork():
                        self._network_name, self._encryption,
                        wrong_password=True)
 
-    def _weak_signal_screen(self, win):
+    def _weak_signal_screen(self):
         '''
         The network cannot be joined because the signal is too weak.
         Show an error message dialog, so the user can easily fix and retry.
@@ -85,7 +84,7 @@ class ConnectToNetwork():
                 'type': 'KanoButton',
                 'color': 'green',
                 # Go to the network refresh screen
-                'callback': self._go_to_network_screen
+                'callback': self._go_to_spinner_screen
             },
             {
                 'label': _("QUIT"),
@@ -95,12 +94,12 @@ class ConnectToNetwork():
         ]
         img_path = os.path.join(img_dir, "no-wifi.png")
 
-        win.set_main_widget(
+        self._win.set_main_widget(
             Template(
                 title,
                 description,
                 buttons,
-                win.is_plug(),
+                self._win.is_plug(),
                 img_path
             )
         )


### PR DESCRIPTION
Bug: 1619 - Wifi No Refresh Issue

Redirect user to the network refresh screens in the gui wifi settings dialogue after a connection failure because of a "weak signal". 

Additionally, modified the .gitignore to include Emacs and VSCode files and dirs. 