### PR TITLE
Use old audio driver to avoid kernel / firmware crash

### DIFF
--- a/boot_default/config.txt
+++ b/boot_default/config.txt
@@ -76,6 +76,11 @@ display_rotate=0
 # Decrease audio noise.
 disable_audio_dither=1
 
+# Disable the new audio pwm driver to avoid the risk of a kernel / firmware crash.
+# https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=195178
+# https://github.com/raspberrypi/linux/issues/2587
+audio_pwm_mode=1
+
 # ---------------------------------------------------------------------------------------
 # Configuration Filters - RPis
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -5,6 +5,7 @@ kano-settings (4.0.6-0) unstable; urgency=low
     ratios that are not 4:3, 16:9, 16:10
   * Fix support for Gtk packages included with Stretch
   * Fixed Safe Mode configuration sometimes not getting applied correctly
+  * Use old audio driver with audio_pwm_mode=1 (default 2 in latest)
 
  -- Team Kano <dev@kano.me>  Fri, 22 Jun 2018 10:17:00 +0100
 


### PR DESCRIPTION
According to https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=195178
it would seem that there was a newer version of the audio driver
introduced and used in Raspbian since 11 Oct 2017. This however
clashes under heavy GPU load when sound is playing as documented here
https://github.com/raspberrypi/linux/issues/2587 As such, revert to
use the old one for added safety.

---

If I remember correctly, we haven't updated our sources since 11 Oct 2017 (need to verify this on 3.15.0). This means that the new audio driver is something else that was introduced when we started upgrading to stretch. We would need to test the quality and regressions if we decide to merge this. Using this option with the old qmlmatrix prevented the crashes we've previously seen.